### PR TITLE
Port to mca.1.12.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,13 @@ This repository contains a formal proof in Coq of LaSalle's invariance
 principle.
 
 This branch requires the [mathcomp-analysis
-library](https://github.com/math-comp/analysis) and its dependencies and the
-[ssring.v](https://raw.githubusercontent.com/jasmin-lang/jasmin/f1f8b193591d369296d5661f0ae8a09f3b6eaa9b/proofs/3rdparty/ssrring.v)
-file from [jasmin](https://github.com/jasmin-lang/jasmin).
+library](https://github.com/math-comp/analysis) and [algebra
+tactics](https://github.com/math-comp/algebra-tactics). More
+precisely, as of 2025-08-25. it compiles with the following versions:
+- Rocq 9.0
+- MathComp 2.4.0
+- MathComp-Analysis 1.12.0
+- algebra-tactics 1.2.6
 
 It is organised as follows:
 
@@ -19,3 +23,6 @@ It is organised as follows:
 # Authors
 
 Cyril Cohen and Damien Rouhling.
+
+Reynald Affeldt ported the development from MathComp-Analysis 0.2.0 to
+MathComp-Analysis 1.12.0 during the summer 2025.

--- a/_CoqProject
+++ b/_CoqProject
@@ -1,4 +1,4 @@
 -R . lasalle
-ssrring.v
+
 lasalle.v
 pendulum.v

--- a/lasalle.v
+++ b/lasalle.v
@@ -38,7 +38,7 @@ rewrite predeqE => p; split.
   wlog Mgt0 : M Mreal ygtM_A / (0 < M)%R; last first.
     by have [t [/ygtM_A Ayt /pe_B Byt]] := plim_p _ egt0 _ Mgt0; exists (y t).
   move=> /(_ (maxr M 1%R)) []; last by move=> q ?; exists q.
-      by rewrite maxr_real.
+      by rewrite max_real// real1.
     by move=> ?; rewrite lt_maxl => /andP [/ygtM_A].
   by rewrite lt_maxr orbC ltr01.
 move=> clyp e egt0 T Tgt0.
@@ -78,14 +78,14 @@ rewrite clusterE [_ `\` _]setI_bigcapl // setIC setI_bigcapl // => IFBoA0.
 set f := fun C => closure C `&` ~` B^° `&` A.
 have [G sGF IGBoA0] : exists2 G : {fset (set U)},
   {subset G <= F} & \bigcap_(C in [set C | C \in G]) f C = set0.
-  have {IFBoA0} IFBoA0 : ~ (\bigcap_(C in F) f C !=set0).
+  have {}IFBoA0 : ~ (\bigcap_(C in F) f C !=set0).
     by move=> [p IFBoAp]; rewrite -[False]/(set0 p) -IFBoA0.
   have /Aco : closed_fam_of A F f.
     exists (fun C => closure C `&` ~` B^°).
       move=> C _; apply: closedI (@closed_closure _ _) _.
       exact/closedC/open_interior.
     by move=> ? _; rewrite setIC.
-  move=> /contrap /(_ IFBoA0) /asboolPn /existsp_asboolPn [H /asboolPn].
+  move=> /contra_not /(_ IFBoA0) /asboolPn /existsp_asboolPn [H /asboolPn].
   move=> /imply_asboolPn [sHF IHBoA0]; exists H => //.
   by rewrite predeqE => p; split=> // IHBoAp; apply: IHBoA0; exists p.
 have Gn0 : [set C | C \in G] !=set0.
@@ -129,7 +129,7 @@ Qed.
 Lemma sub_image_at_infty (y : R -> U) (A : set U) : y @` (>= 0)%R `<=` A -> (y @ +oo%R) A.
 Proof.
 move=> syRpA; exists 0%R; split.
-  by rewrite realE lexx.
+  by rewrite real0.
 move=> t tgt0.
 exact/syRpA/imageP/ltW.
 Qed.
@@ -174,7 +174,8 @@ wlog Ngt0 : N Nreal ybndN / (0 < N)%R.
   move=> bnd_plim; apply: (bnd_plim (maxr N 1%R)); last first.
     by rewrite lt_maxr orbC ltr01.
   by move=> ?; rewrite lt_maxl => /andP [/ybndN].
-  by rewrite maxr_real.
+  by rewrite max_real// real1.
+rewrite /bounded_set.
 red.
 near=> M => p plimp.
 have [] := plimp (y @` (>= 0)%R) (ball_ Num.norm p (PosNum Ngt0)%:num).
@@ -231,7 +232,7 @@ Hypothesis sol_cont : forall t, continuous_on K (sol^~ t).
 
 Lemma sol_is_sol p : K p -> is_sol (sol p).
 Proof. by move=> Kp; apply/solP; rewrite sol0. Qed.
-Hint Resolve sol_is_sol.
+Hint Resolve sol_is_sol : core.
 
 Lemma uniq_sol (x y : R -> U) :
   K (x 0%R) -> K (y 0%R) -> is_sol x -> is_sol y -> x 0%R = y 0%R -> x = y.
@@ -285,14 +286,25 @@ suff dshift : (shift_sol p t0) \o shift t = (cst (shift_sol p t0 t) +
   have diff_shift : differentiable (shift_sol p t0 : R^o -> _) t.
     apply/diff_locallyP; split; last first.
       apply/eqaddoE; rewrite dshift.
-      do 2 congr +%R.
+(* 0.3.6:
+  (cst (shift_sol p t0 t) +  *:%R^~ (F (shift_sol p t0 t)) + 'o_[filter of 0] id )%R =
+  (cst (shift_sol p t0 t) + 'd (shift_sol p t0) t + 'a_o_(nbhs_filter_on 0) id )%R *)
+      congr +%R.
+(* 0.3.6:
+  (cst (shift_sol p t0 t) +  *:%R^~ (F (shift_sol p t0 t)))%R =
+  (cst (shift_sol p t0 t) + 'd (shift_sol p t0) t)%R *)
+      congr +%R.
       abstract: dshiftE.
       have lin_scal : linear (fun h : R^o => h *: F (shift_sol p t0 t))%R.
         by move=> ???; rewrite scalerDl scalerA.
       have ->: (fun h : R^o => h *: F (shift_sol p t0 t))%R = Linear lin_scal by [].
       apply/esym.
       apply: diff_unique; first exact: scalel_continuous.
-      by apply/eqaddoE; rewrite dshift.
+      apply/eqaddoE; rewrite dshift.
+(* 0.3.6:
+  (cst (shift_sol p t0 t) +  *:%R^~ (F (shift_sol p t0 t)) + 'o_[filter of 0] id )%R =
+  (cst (shift_sol p t0 t) + Linear lin_scal + 'a_o_(nbhs_filter_on 0) id )%R *)
+      by [].
     by rewrite -dshiftE; apply: scalel_continuous.
   apply: DeriveDef; first exact/derivable1_diffP.
   by rewrite deriveE // -dshiftE scale1r.
@@ -306,7 +318,9 @@ move: tge0; rewrite le_eqVlt orbC => /orP [tgt0|/eqP teq0].
   rewrite funeqE => /(_ s) /=; rewrite addrA [(_%:A)%R]mulr1 =>->.
   suff -> /= : (0 <= s + t)%R.
     rewrite derive_val addrC addrA [(_ s + _)%R]addrC subrr add0r; near: s.
-    by case: e => /=; apply/(eqoP (nbhs_filter_on (0%R : R))).
+    case: e => /=; apply/(eqoP (nbhs_filter_on (0%R : R))).
+    (* 0.3.6: 'o_[filter of nbhs 0%R] id  = 'o_(nbhs_filter_on 0%R) id  *)
+    by [].
   near: s; exists t => // s; rewrite /ball_ /= => ltst.
   rewrite -ler_subl_addl sub0r; apply/ltW; apply: le_lt_trans ltst.
   by rewrite sub0r ler_norm.
@@ -321,7 +335,10 @@ have := dsol; rewrite funeqE => /(_ (- s)%R) /=; rewrite [(_%:A)%R]mulr1 =>->.
 have := dsol; rewrite funeqE => /(_ s) /=; rewrite [(_%:A)%R]mulr1 =>->.
 rewrite -{1}teq0 derive_val; case: (lerP 0 s) => [le0s|lts0].
   rewrite addrC addrA [(_ s + _)%R]addrC subrr add0r; near: s.
-  by case: e => /=; apply/(eqoP (nbhs_filter_on (0%R : R))).
+  case: e => /=; apply/(eqoP (nbhs_filter_on (0%R : R))).
+(* 0.3.6:
+  'o_[filter of nbhs 0%R] id  = 'o_(nbhs_filter_on 0%R) id *)
+  by [].
 rewrite !opprD oppox /cst /= addrACA -[(- _ : _ -> _)%R _]/(- _)%R !addrA.
 rewrite mulr2n scalerDl scale1r -[(_ - _ - sol _ _)%R]addrA -opprD subrr sub0r.
 rewrite scaleNr opprK addrC addKr -[in X in (_ <= X)%R]normrN; near: s.
@@ -352,14 +369,14 @@ move=> Kp q plim_q t0 t0_ge0 A B [M].
 wlog Mge0 : M / (0 <= M)%R => [sufMge0|] [Mreal solpMinfty_A].
   apply: (sufMge0 (maxr 0%R M)); first by rewrite le_maxr lexx.
   split.
-    by rewrite maxr_real.
+    by rewrite max_real// real0.
   by move=> x; rewrite lt_maxl => /andP[_]; apply: solpMinfty_A.
 have Kq : K q.
   apply: compact_closed => //.
   move=> C qC.
   move: plim_q; apply => //.
   exists 0%R; split.
-    by rewrite realE lexx.
+    by rewrite real0.
   move=> t /ltW tge0.
   by apply: Kinvar.
 move=> /(sol_cont Kq) /plim_q q_Bsolt0.
@@ -413,11 +430,18 @@ have ssqRpK : sol q @` (>= 0)%R `<=` K by move=> _ [t tge0 <-]; apply: Kinvar.
 (* should be inferred *)
 have atrF := at_right_proper_filter 0%R.
 suff : exists l, cluster (sol q @ +oo%R) `<=` V @^-1` [set l].
-  move=> [l Vpliml]; rewrite derive1E /derive cvg_at_rightE; last first.
+  move=> [l Vpliml]/=; rewrite derive1E /derive cvg_at_rightE; last first.
     apply: Vsol_drvbl => //; apply: compact_closed => //.
     exact: sub_plim_clos_invar plimp.
-  apply: (@cvg_map_lim _ _ _ (at_right _)) => // A A0; rewrite !near_simpl; near=> h.
-  rewrite /= sol0 addr0 [(_%:A)%R]mulr1 Vpliml.
+  apply: (@cvg_map_lim _ _ _ (at_right _)) => // A A0.
+    rewrite -closeEnbhs.
+     move/close_eq; apply.
+     exact: Rhausdorff.
+  rewrite !near_simpl; near=> h.
+  rewrite /= sol0 addr0.
+  rewrite [X in sol p X](_ : _ = h); last first.
+    by rewrite /GRing.scale/= mulr1.
+  rewrite Vpliml//.
     by rewrite Vpliml // subrr scaler0; apply: nbhs_singleton.
   by apply: invariant_plim => //; apply: ltW; near: h; exists 1%R.
 suff cvVsol : cvg (V \o sol q @ +oo%R).
@@ -443,9 +467,13 @@ rewrite derive1E /derive cvg_at_rightE; last first.
   by apply: Vsol_drvbl => //; apply: Kinvar.
 congr (lim _); rewrite predeqE /= nbhs_filterE => A; split.
   move=> [_/posnumP[e] Ae]; exists e%:num%R => // x xe xgt0.
-  by rewrite sol0 addr0 -solD //; [apply: Ae|rewrite [(_%:A)%R]mulr1 ltW].
+  rewrite sol0/=.
+  rewrite addr0 -solD //; [by apply: Ae|].
+  by rewrite /GRing.scale/= mulr1 ltW.
 move=> [_/posnumP[e] Ae]; exists e%:num%R => // x xe xgt0.
-by have /Ae - /(_ xe) := xgt0; rewrite sol0 addr0 -solD // [(_%:A)%R]mulr1 ltW.
+have /Ae - /(_ xe) := xgt0.
+rewrite sol0/= addr0 -solD //.
+by rewrite /GRing.scale/= mulr1 ltW.
 Grab Existential Variables. all: end_near. Qed.
 
 Lemma cvg_to_limS (A : set U) : compact A -> is_invariant A ->

--- a/lasalle.v
+++ b/lasalle.v
@@ -1,7 +1,7 @@
 From mathcomp Require Import ssreflect ssrfun ssrbool ssrnat eqtype choice seq.
 From mathcomp Require Import order.
 From mathcomp Require Import fintype bigop ssralg ssrnum finmap interval ssrint.
-From mathcomp Require Import boolp reals Rstruct classical_sets posnum.
+From mathcomp Require Import boolp reals Rstruct classical_sets posnum functions.
 From mathcomp Require Import topology normedtype landau derive.
 
 Set Implicit Arguments.
@@ -84,7 +84,7 @@ have [G sGF IGBoA0] : exists2 G : {fset (set U)},
   have /Aco : closed_fam_of A F f.
     exists (fun C => closure C `&` ~` B^°).
       move=> C _; apply: closedI (@closed_closure _ _) _.
-      exact/closedC/open_interior.
+      by rewrite closedC; exact/open_interior.
     by move=> ? _; rewrite setIC.
   move=> /contra_not /(_ IFBoA0) /asboolPn /existsp_asboolPn [H /asboolPn].
   move=> /imply_asboolPn [sHF IHBoA0]; exists H => //.
@@ -190,7 +190,7 @@ rewrite ler_subr_addr addrC -ler_subr_addr; apply: ybndN; last by exists t.
 rewrite ltr_subr_addr; near: M; exists (N + N)%R.
 split => //.
 by rewrite realD.
-Grab Existential Variables. all: end_near. Qed.
+Unshelve. all: by end_near. Qed.
 
 Lemma continuous_on_compact (S T : topologicalType) (f : S -> T) (A : set S) :
   continuous_on A f -> compact A -> compact (f @` A).
@@ -234,7 +234,7 @@ Import numFieldTopology.Exports.
 Section DifferentialSystem.
 Context {R : realType}.
 Variable U : normedModType R.
-Let hU : hausdorff U := @norm_hausdorff _ U.
+Let hU : hausdorff_space U := @norm_hausdorff _ U.
 
 (* function defining the differential system *)
 Variable F : U -> U.
@@ -319,8 +319,12 @@ move: tge0; rewrite le_eqVlt orbC => /orP [tgt0|/eqP teq0].
   have /derivable_nbhs : derivable (sol p : R^o -> U) (t + t0) 1 by [].
   rewrite funeqE => /(_ s) /=; rewrite addrA [(_%:A)%R]mulr1 =>->.
   suff -> /= : (0 <= s + t)%R.
-    rewrite derive_val addrC addrA [(_ s + _)%R]addrC subrr add0r; near: s.
-    case: e => /=; apply/(eqoP (nbhs_filter_on (0%R : R))).
+    rewrite derive_val addrC addrA [(_ s + _)%R]addrC subrr add0r.
+    near: s.
+    case: e => /= e.
+    rewrite eq_sym -lt_neqAle.
+    move: e.
+    apply/(eqoP (nbhs_filter_on (0%R : R))).
     (* 0.3.6: 'o_[filter of nbhs 0%R] id  = 'o_(nbhs_filter_on 0%R) id  *)
     by [].
   near: s; exists t => // s; rewrite /ball_ /= => ltst.
@@ -330,13 +334,18 @@ rewrite -teq0.
 rewrite shift0.
 rewrite add0r.
 apply/eqaddoP => _ /posnumP[e]; near=> s.
-rewrite -![(_ + _ : _ -> _)%R _]/(_ + _)%R /= -[t0]add0r teq0.
+rewrite -![(_ + _ : _ -> _)%R _]/(_ + _)%R /=.
+rewrite -[t0]add0r/=.
+rewrite {1 2 3 4 5 6}teq0.
 have /derivable_nbhs dsol : derivable (sol p : R^o -> U) (t + t0) 1 by [].
 have := dsol; rewrite funeqE => /(_ (- s)%R) /=; rewrite [(_%:A)%R]mulr1 =>->.
 have := dsol; rewrite funeqE => /(_ s) /=; rewrite [(_%:A)%R]mulr1 =>->.
 rewrite -{1}teq0 derive_val; case: (lerP 0 s) => [le0s|lts0].
   rewrite addrC addrA [(_ s + _)%R]addrC subrr add0r; near: s.
-  case: e => /=; apply/(eqoP (nbhs_filter_on (0%R : R))).
+  case: e => /= e.
+  rewrite eq_sym -lt_neqAle.
+  move: e.
+  apply/(eqoP (nbhs_filter_on (0%R : R))).
 (* 0.3.6:
   'o_[filter of nbhs 0%R] id  = 'o_(nbhs_filter_on 0%R) id *)
   by [].
@@ -345,13 +354,14 @@ rewrite mulr2n scalerDl scale1r -[(_ - _ - sol _ _)%R]addrA -opprD subrr sub0r.
 rewrite scaleNr opprK addrC addKr -[in X in (_ <= X)%R]normrN; near: s.
 rewrite !near_simpl.
 rewrite -(nearN (fun x : R^o => `|_ x| <= e%:num * `|x|%R))%R.
-case: e => /= e e0.
+case: e => /= e.
+rewrite eq_sym -lt_neqAle => e0.
 near=> x.
 set u := (X in `|X x|%R).
 near: x.
 have := (@eqoP _ _ _ _ (nbhs_filter_on (0%R : R^o)) id u).1.
-exact.
-Grab Existential Variables. all: end_near. Qed.
+by apply => //.
+Unshelve. all: by end_near. Qed.
 
 Lemma solD p t0 t :
   K p -> (0 <= t0)%R -> (0 <= t)%R -> sol p (t + t0) = sol (sol p t0) t.
@@ -406,7 +416,10 @@ move=> A /nbhs_ballP [_ /posnumP[e] infe_A].
 have imf_inf : has_inf (fun x => x \in f @` (>= 0)%R).
    split; first by exists (f 0%R); rewrite in_setE; apply: imageP.
   by exists M; apply/lbP => ?; rewrite in_setE => /ltMf /ltW.
-have := imf_inf => /inf_adherent /(_ [gt0 of e%:num]%R) [x].
+have := imf_inf => /inf_adherent.
+move=> /(_ e%:num)%R.
+have e0 : (0 < e%:num)%R by [].
+move=> /(_ e0) [x].
 rewrite in_setE => -[t tge0 <-] ltftinfe; exists t; split.
   by rewrite realE tge0.
 move=> s ltts; apply: infe_A.
@@ -443,7 +456,7 @@ suff : exists l, cluster (sol q @ +oo%R) `<=` V @^-1` [set l].
     by rewrite /GRing.scale/= mulr1.
   rewrite Vpliml//.
     by rewrite Vpliml // subrr scaler0; apply: nbhs_singleton.
-  by apply: invariant_plim => //; apply: ltW; near: h; exists 1%R.
+  by apply: invariant_plim => //; apply: ltW; near: h; exists 1%R => //=.
 suff cvVsol : cvg (V \o sol q @ +oo%R).
   exists (lim (V \o sol q @ +oo%R)); apply: (c0_cvg_cst_on_plim Vcont)=> //.
   exact: compact_closed.
@@ -456,8 +469,14 @@ apply: nincr_lb_cvg; last first.
   rewrite (@le_lt_trans _ _ (N + 1)%R)// ?ltr_add2l ?ltr1n//.
   by apply: imVltN.2; [rewrite ltr_addl|apply/imageP/Kinvar].
 move=> s t /andP [sge0 slet].
-apply: ler0_derive1_nincr (lexx _) slet (lexx _).
-  move=> r rst; apply: Vsol_drvbl => //; apply: le_trans sge0 _.
+apply: ler0_derive1_nincr (lexx _) slet (lexx _); first 2 last.
+  apply: continuous_subspaceT => x.
+  rewrite inE/= in_itv/= => /andP[sx xt].
+  have := Vsol_drvbl _ _ Kq (le_trans sge0 sx).
+  move/derivable1_diffP/differentiable_continuous.
+  by apply.
+  move=> r rst.
+  apply: Vsol_drvbl => //; apply: le_trans sge0 _.
   by rewrite (itvP rst).
 move=> r rst; have rge0 : (0 <= r)%R by apply: le_trans sge0 _; rewrite (itvP rst).
 suff -> : derive1 (V \o sol q) r = derive1 (V \o (sol (sol q r))) 0.
@@ -466,15 +485,15 @@ rewrite derive1E /derive cvg_at_rightE; last exact: Vsol_drvbl.
 rewrite derive1E /derive cvg_at_rightE; last first.
   by apply: Vsol_drvbl => //; apply: Kinvar.
 congr (lim _); rewrite predeqE /= nbhs_filterE => A; split.
-  move=> [_/posnumP[e] Ae]; exists e%:num%R => // x xe xgt0.
+  move=> [_/posnumP[e] Ae]; exists e%:num%R=> //= x xe xgt0.
   rewrite sol0/=.
   rewrite addr0 -solD //; [by apply: Ae|].
   by rewrite /GRing.scale/= mulr1 ltW.
-move=> [_/posnumP[e] Ae]; exists e%:num%R => // x xe xgt0.
+move=> [_/posnumP[e] Ae]; exists e%:num%R => //= x xe xgt0.
 have /Ae - /(_ xe) := xgt0.
 rewrite sol0/= addr0 -solD //.
 by rewrite /GRing.scale/= mulr1 ltW.
-Grab Existential Variables. all: end_near. Qed.
+Unshelve. all: by end_near. Qed.
 
 Lemma cvg_to_limS (A : set U) : compact A -> is_invariant A ->
   forall p, A p -> sol p @ +oo%R --> (limS A : set [pseudoMetricType _ of U]).
@@ -482,9 +501,8 @@ Proof.
 move=> Aco Ainvar p Ap B [_/posnumP[e] limSeB].
 apply: (cvg_to_plim _ Aco).
   exists 0%R; split => //.
-    by rewrite realE lexx.
   by move=> _/posnumP[?]; apply: Ainvar.
-by exists e%:num%R=> // q [r plimr re_q]; apply: limSeB; exists r => //; exists p.
+by exists e%:num%R=> //= q [r plimr re_q]; apply: limSeB; exists r => //; exists p.
 Qed.
 
 End DifferentialSystem.

--- a/lasalle.v
+++ b/lasalle.v
@@ -1,4 +1,3 @@
-Require Import Reals.
 From mathcomp Require Import ssreflect ssrfun ssrbool ssrnat eqtype choice seq.
 From mathcomp Require Import order.
 From mathcomp Require Import fintype bigop ssralg ssrnum finmap interval ssrint.
@@ -74,7 +73,9 @@ have : A `&` (cluster F `\` B^°) = set0.
   suff -> : cluster F `\` B^° = set0 by rewrite setI0.
   rewrite setD_eq0 => p clFp.
   by rewrite /interior -nbhs_ballE; exists e => // ??; exists p.
-rewrite clusterE [_ `\` _]setI_bigcapl // setIC setI_bigcapl // => IFBoA0.
+rewrite clusterE.
+rewrite -[_ `\` _]bigcapIl // setIC.
+rewrite -bigcapIl // => IFBoA0.
 set f := fun C => closure C `&` ~` B^° `&` A.
 have [G sGF IGBoA0] : exists2 G : {fset (set U)},
   {subset G <= F} & \bigcap_(C in [set C | C \in G]) f C = set0.
@@ -94,7 +95,7 @@ have Gn0 : [set C | C \in G] !=set0.
 move: IGBoA0; have -> : \bigcap_(C in [set C | C \in G]) f C =
   \bigcap_(C in [set C | C \in G]) (A `&` closure C `&` ~` B^°).
   by rewrite predeqE => a; split=> IGBoAa ? /IGBoAa [[]].
-rewrite -setI_bigcapl // setD_eq0 => sIGABo.
+rewrite bigcapIl // setD_eq0 => sIGABo.
 suff : F B^° by apply: filterS => ?; apply: nbhs_singleton.
 apply: filterS sIGABo _; apply: filter_bigI => C /sGF; rewrite in_setE => FC.
 by apply: filterI FA _; apply: filterS (@subset_closure _ C) _.
@@ -169,7 +170,7 @@ End PositiveLimitingSet.
 Lemma bounded_plim (K : realFieldType) (V : normedModType K) (y : K -> V) :
   bounded_set (y @` (>= 0)%R) -> bounded_set (cluster (y @ +oo%R)).
 Proof.
-rewrite /bounded => - [N [Nreal ybndN]].
+rewrite /bounded_set => - [N [Nreal ybndN]].
 wlog Ngt0 : N Nreal ybndN / (0 < N)%R.
   move=> bnd_plim; apply: (bnd_plim (maxr N 1%R)); last first.
     by rewrite lt_maxr orbC ltr01.
@@ -208,8 +209,30 @@ have : G (A `&` f @^-1` B) by exists B.
 by move=> /clsGp /(_ p_Cf) [q [[Aq ?] /(_ Aq)]]; exists (f q).
 Qed.
 
-Section DifferentialSystem.
+(* to mathcomp/analysis *)
+Lemma nearN (R : realFieldType) (P : set R) :
+  (\forall x \near (0%R : R^o), P x) = (\forall x \near (0%R : R^o), P (- x)%R).
+Proof.
+rewrite propeqE; split.
+  move/(@nbhs_ballP _ [the pseudoMetricType _ of R^o]).
+  move=> [e egt0 seP]; exists e => // x.
+  move=> ex.
+  apply: seP.
+  move: ex.
+  by rewrite /ball/= /ball_/= opprK !add0r normrN.
+move/(@nbhs_ballP _ [the pseudoMetricType _ of R^o]).
+move=> [e egt0 seP]; exists e => // x.
+move=> ex.
+rewrite -(opprK x).
+apply: seP.
+move: ex.
+by rewrite /ball/= /ball_/= opprK !add0r normrN.
+Qed.
 
+Import numFieldTopology.Exports.
+
+Section DifferentialSystem.
+Context {R : realType}.
 Variable U : normedModType R.
 Let hU : hausdorff U := @norm_hausdorff _ U.
 
@@ -245,34 +268,13 @@ Hypothesis Kinvar : is_invariant K.
 Definition shift_sol p t0 t :=
   (if t >= 0 then sol p (t + t0) else 2 *: (sol p t0) - (sol p (- t + t0)))%R.
 
-(* to mathcomp/analysis *)
-Lemma nearN (R : realFieldType) (P : set R) :
-  (\forall x \near (0%R : R^o), P x) = (\forall x \near (0%R : R^o), P (- x)%R).
-Proof.
-rewrite propeqE; split.
-  move/(@nbhs_ballP _ [the pseudoMetricType _ of R^o]).
-  move=> [e egt0 seP]; exists e => // x.
-  move=> ex.
-  apply: seP.
-  move: ex.
-  by rewrite /ball/= /ball_/= opprK !add0r normrN.
-move/(@nbhs_ballP _ [the pseudoMetricType _ of R^o]).
-move=> [e egt0 seP]; exists e => // x.
-move=> ex.
-rewrite -(opprK x).
-apply: seP.
-move: ex.
-by rewrite /ball/= /ball_/= opprK !add0r normrN.
-Qed.
-
 Lemma sol_shift p (t0 : R^o) : K p -> (0 <= t0)%R -> is_sol (shift_sol p t0).
 Proof.
 move=> Kp t0ge0; split=> [t tlt0|t tge0].
   rewrite /shift_sol leNgt tlt0/= lexx/=.
   rewrite ltW ?oppr_gt0//.
   rewrite [X in _ = (2 *: sol p X - _)%R](_ : _ = t0)//.
-  set tmp := (0 + t0)%R.
-  by rewrite RplusE add0r.
+  by rewrite add0r.
 suff dshift : (shift_sol p t0) \o shift t = (cst (shift_sol p t0 t) +
   (fun h : R^o => h *: F (shift_sol p t0 t)))%R +o_ (0%R : R^o) (id : R^o -> R^o).
 (*  have dshiftE : 'd (shift_sol p t0) (t : R^o) =
@@ -326,7 +328,6 @@ move: tge0; rewrite le_eqVlt orbC => /orP [tgt0|/eqP teq0].
   by rewrite sub0r ler_norm.
 rewrite -teq0.
 rewrite shift0.
-rewrite RplusE.
 rewrite add0r.
 apply/eqaddoP => _ /posnumP[e]; near=> s.
 rewrite -![(_ + _ : _ -> _)%R _]/(_ + _)%R /= -[t0]add0r teq0.
@@ -357,7 +358,6 @@ Lemma solD p t0 t :
 Proof.
 move=> Kp t0ge0 tge0; have /sol_shift /(_ t0ge0) /solP := Kp.
 rewrite [shift_sol _ _ _]/shift_sol lexx.
-rewrite RplusE.
 rewrite add0r.
 move=> <-; last exact: Kinvar.
 by rewrite /shift_sol tge0.

--- a/lasalle.v
+++ b/lasalle.v
@@ -8,7 +8,9 @@ From mathcomp Require Import topology normedtype landau derive.
 Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.
+
 Import GRing.Theory Num.Def Num.Theory Order.POrderTheory Order.TotalTheory.
+Import numFieldTopology.Exports.
 
 Local Open Scope classical_set_scope.
 
@@ -48,16 +50,10 @@ rewrite predeqE => p; split.
   by rewrite lt_max orbC ltr01.
 move=> clyp e egt0 T Tgt0.
 have [] := clyp (y @` ltr T) (ball p e).
-  exists T; split => //.
-    by rewrite realE (ltW Tgt0).
-  by apply: imageP.
+  by exists T; rewrite num_real; split => //; exact: imageP.
   by rewrite -nbhs_ballE; exists e.
 by move=> _ [[t ? <-] ?]; exists t.
 Qed.
-
-(* mathcomp/analysis issue: should be inferred *)
-Instance infty_proper : @ProperFilter R +oo%R.
-Proof. exact: proper_pinfty_nbhs. Qed.
 
 Lemma plimn0 (y : R -> U) (A : set U) :
   compact A -> (y @ +oo%R) A -> cluster (y @ +oo%R) !=set0.
@@ -111,7 +107,7 @@ Lemma cvg_to_plim (y : R -> U) (A : set U) :
   (y @ +oo%R) A -> compact A -> y @ +oo%R --> cluster (y @ +oo%R).
 Proof.
 move=> yinftyA coA B [e egt0 scleB].
-by apply: filterS scleB _; apply: filter_cluster coA _ egt0.
+by apply: filterS scleB _; exact: filter_cluster coA _ egt0.
 Qed.
 
 (* Lemma cvg_to_plim y (A : set U) : *)
@@ -133,17 +129,16 @@ Qed.
 (* by exists p => // C D yinftyC; apply/plimnBp; apply: flim_within yinftyC. *)
 (* Qed. *)
 
-Lemma sub_image_at_infty (y : R -> U) (A : set U) : y @` (>= 0)%R `<=` A -> (y @ +oo%R) A.
+Lemma sub_image_at_infty (y : R -> U) (A : set U) :
+  y @` (>= 0)%R `<=` A -> (y @ +oo%R) A.
 Proof.
-move=> syRpA; exists 0%R; split.
-  by rewrite real0.
-move=> t tgt0.
+move=> syRpA; exists 0%R; rewrite real0; split => // t tgt0.
 exact/syRpA/imageP/ltW.
 Qed.
 
 Lemma sub_plim_clos_invar (y : R -> U) (A : set U) :
   y @` (>= 0)%R `<=` A -> cluster (y @ +oo%R) `<=` closure A.
-Proof. by move=> syRpA p ypp B /ypp; apply; apply: sub_image_at_infty. Qed.
+Proof. by move=> syRpA p ypp B /ypp; apply; exact: sub_image_at_infty. Qed.
 
 (* to mathcomp/analysis ? *)
 Definition continuous_on (T U : topologicalType) (A : set T) (f : T -> U) :=
@@ -193,9 +188,7 @@ apply: (le_trans (ler_normD _ _)).
 rewrite -lerBrDr.
 apply/ltW; apply: lt_le_trans pN_yt _.
 rewrite lerBrDr addrC -lerBrDr; apply: ybndN; last by exists t.
-rewrite ltrBrDr; near: M; exists (N + N)%R.
-split => //.
-by rewrite realD.
+by rewrite ltrBrDr; near: M; exists (N + N)%R; rewrite realD.
 Unshelve. all: by end_near. Qed.
 
 Lemma continuous_on_compact (S T : topologicalType) (f : S -> T) (A : set S) :
@@ -215,27 +208,19 @@ have : G (A `&` f @^-1` B) by exists B.
 by move=> /clsGp /(_ p_Cf) [q [[Aq ?] /(_ Aq)]]; exists (f q).
 Qed.
 
-(* to mathcomp/analysis *)
+(* TODO: PR to mathcomp-analysis? *)
 Lemma nearN (R : realFieldType) (P : set R) :
   (\forall x \near (0%R : R^o), P x) = (\forall x \near (0%R : R^o), P (- x)%R).
 Proof.
 rewrite propeqE; split.
-  move/(@nbhs_ballP _ [the pseudoMetricType _ of R^o]).
-  move=> [e egt0 seP]; exists e => // x.
-  move=> ex.
-  apply: seP.
-  move: ex.
-  by rewrite /ball/= /ball_/= opprK !add0r normrN.
-move/(@nbhs_ballP _ [the pseudoMetricType _ of R^o]).
-move=> [e egt0 seP]; exists e => // x.
-move=> ex.
-rewrite -(opprK x).
-apply: seP.
-move: ex.
-by rewrite /ball/= /ball_/= opprK !add0r normrN.
-Qed.
-
-Import numFieldTopology.Exports.
+  move/nbhs_ballP => [e e0 eP].
+  near=> x; apply: eP; rewrite /ball/= opprK add0r.
+  by near: x; exact: (@nbhs0_lt _ R^o).
+move/nbhs_ballP => [e e0 eP].
+near=> x.
+rewrite -(opprK x); apply: eP; rewrite /ball/= opprK add0r.
+by near: x; exact: (@nbhs0_lt _ R^o).
+Unshelve. all: by end_near. Qed.
 
 Section DifferentialSystem.
 Context {R : realType}.
@@ -254,7 +239,7 @@ Variable K : set U.
 Hypothesis Kco : compact K.
 
 (* solution function *)
-Variable (sol : U -> R -> U).
+Variable sol : U -> R -> U.
 Hypothesis (sol0 : forall p, sol p 0 = p).
 Hypothesis solP : forall y : R -> U, K (y 0%R) -> is_sol y <-> y = sol (y 0%R).
 Hypothesis sol_cont : forall t, continuous_on K (sol^~ t).
@@ -283,20 +268,10 @@ move=> Kp t0ge0; split=> [t tlt0|t tge0].
   by rewrite add0r.
 suff dshift : (shift_sol p t0) \o shift t = (cst (shift_sol p t0 t) +
   (fun h : R^o => h *: F (shift_sol p t0 t)))%R +o_ (0%R : R^o) (id : R^o -> R^o).
-(*  have dshiftE : 'd (shift_sol p t0) (t : R^o) =
-    (fun h => h *: F (shift_sol p t0 t))%R :> (R^o -> U).
-    have lin_scal : linear (fun h : R^o => h *: F (shift_sol p t0 t)).
-      by move=> ???; rewrite scalerDl scalerA.
-    have ->: (fun h : R^o => h *: F (shift_sol p t0 t)) = Linear lin_scal by [].
-    apply: diff_unique; first exact: scalel_continuous.
-    by apply/eqaddoE; rewrite dshift.*)
   move=> [:dshiftE].
   have diff_shift : differentiable (shift_sol p t0 : R^o -> _) t.
     apply/diff_locallyP; split; last first.
       apply/eqaddoE; rewrite dshift.
-(* 0.3.6:
-  (cst (shift_sol p t0 t) +  *:%R^~ (F (shift_sol p t0 t)) + 'o_[filter of 0] id )%R =
-  (cst (shift_sol p t0 t) + 'd (shift_sol p t0) t + 'a_o_(nbhs_filter_on 0) id )%R *)
       congr +%R.
 (* 0.3.6:
   (cst (shift_sol p t0 t) +  *:%R^~ (F (shift_sol p t0 t)))%R =
@@ -307,7 +282,7 @@ suff dshift : (shift_sol p t0) \o shift t = (cst (shift_sol p t0 t) +
         by move=> ???; rewrite scalerDl scalerA.
       pose glM := GRing.isLinear.Build _ _ _ _ _ lin_scal.
       pose gL : {linear R^o -> U} := HB.pack ( *:%R^~ (F (shift_sol p t0 t))) glM.
-      have ->: (fun h : R^o => h *: F (shift_sol p t0 t))%R = gL by [].
+      have -> : (fun h : R^o => h *: F (shift_sol p t0 t))%R = gL by [].
       apply/esym.
       apply: diff_unique; first exact: scalel_continuous.
       apply/eqaddoE; rewrite dshift.
@@ -358,8 +333,7 @@ rewrite -{1}teq0 derive_val; case: (lerP 0 s) => [le0s|lts0].
   'o_[filter of nbhs 0%R] id  = 'o_(nbhs_filter_on 0%R) id *)
   by [].
 rewrite !opprD oppox /cst /= addrACA -[(- _ : _ -> _)%R _]/(- _)%R !addrA.
-rewrite [X in (X *: _)%R](_ : _ = (1 + 1)%R); last first.
-  done.
+rewrite [X in (X *: _)%R](_ : _ = (1 + 1)%R); last by [].
 rewrite scalerDl scale1r -[(_ - _ - sol _ _)%R]addrA -opprD subrr sub0r.
 rewrite scaleNr opprK addrC addKr -[in X in (_ <= X)%R]normrN; near: s.
 rewrite !near_simpl.
@@ -369,8 +343,7 @@ rewrite /Itv.num_sem num_real in_itv/= andbT => e0.
 near=> x.
 set u := (X in `|X x|%R).
 near: x.
-have := (@eqoP _ _ _ _ (nbhs_filter_on (0%R : R^o)) id u).1.
-by apply => //.
+exact: (@eqoP _ _ _ _ (nbhs_filter_on (0%R : R^o)) id u).1.
 Unshelve. all: by end_near. Qed.
 
 Lemma solD p t0 t :
@@ -392,11 +365,9 @@ wlog Mge0 : M / (0 <= M)%R => [sufMge0|] [Mreal solpMinfty_A].
     by rewrite max_real// real0.
   by move=> x; rewrite gt_max => /andP[_]; apply: solpMinfty_A.
 have Kq : K q.
-  apply: compact_closed => //.
-  move=> C qC.
+  apply: compact_closed => // C qC.
   move: plim_q; apply => //.
-  exists 0%R; split => //.
-  move=> t /ltW tge0.
+  exists 0%R; split => // t /ltW tge0.
   exact: Kinvar.
 move=> /(sol_cont Kq) /plim_q q_Bsolt0.
 have /q_Bsolt0 [_ [[[t tgtM <-] _]]] : (sol p @ +oo%R) (sol p @` (> M)%R `&` A).
@@ -404,7 +375,7 @@ have /q_Bsolt0 [_ [[[t tgtM <-] _]]] : (sol p @ +oo%R) (sol p @` (> M)%R `&` A).
 have tge0 : (0 <= t)%R by apply/ltW; apply: le_lt_trans tgtM.
 have Ksolpt : K (sol p t) by apply: Kinvar.
 move=> /(_ Ksolpt) /=; rewrite -solD // => Bsolpt0t; exists (sol p (t0 + t)).
-by split=> //; apply/solpMinfty_A/ltr_wpDl.
+by split=> //; exact/solpMinfty_A/ltr_wpDl.
 Qed.
 
 Definition limS (A : set U) := \bigcup_(q in A) cluster (sol q @ +oo%R).
@@ -423,15 +394,12 @@ move=> fnincr [M ltMf].
 apply/cvg_ex; exists (inf (fun x => x \in f @` (>= 0)%R)).
 move=> A /nbhs_ballP [_ /posnumP[e] infe_A].
 have imf_inf : has_inf (fun x => x \in f @` (>= 0)%R).
-   split; first by exists (f 0%R); rewrite in_setE; apply: imageP.
+  split; first by exists (f 0%R); rewrite in_setE; apply: imageP.
   by exists M; apply/lbP => ?; rewrite in_setE => /ltMf /ltW.
-have := imf_inf => /inf_adherent.
-move=> /(_ e%:num)%R.
-have e0 : (0 < e%:num)%R by [].
-move=> /(_ e0) [x].
-rewrite in_setE => -[t tge0 <-] ltftinfe; exists t; split.
-  by rewrite realE tge0.
-move=> s ltts; apply: infe_A.
+have := imf_inf => /inf_adherent => /(_ e%:num)%R.
+move=> /(_ (gt0 e)) [x].
+rewrite in_setE => -[t tge0 <-] ltftinfe.
+exists t; rewrite num_real; split => // s ltts; apply: infe_A.
 rewrite /ball/=.
 rewrite distrC ger0_norm.
   rewrite ltrBlDl.
@@ -440,7 +408,7 @@ rewrite subr_ge0.
 apply: inf_lbound => //.
   by case: imf_inf.
 rewrite in_setE; apply: imageP.
-by apply: ltW; apply: le_lt_trans ltts.
+by apply: ltW; exact: le_lt_trans ltts.
 Qed.
 
 (* todo: use directional derivative *)
@@ -453,7 +421,7 @@ Proof.
 move=> Vcont Vsol_drvbl Vsol'le0 p [q Kq plimp].
 have ssqRpK : sol q @` (>= 0)%R `<=` K by move=> _ [t tge0 <-]; apply: Kinvar.
 (* should be inferred *)
-have atrF := at_right_proper_filter 0%R.
+(*have atrF := at_right_proper_filter 0%R. (* is it now?*) *)
 suff : exists l, cluster (sol q @ +oo%R) `<=` V @^-1` [set l].
   move=> [l Vpliml]/=; rewrite derive1E /derive cvg_at_rightE; last first.
     apply: Vsol_drvbl => //; apply: compact_closed => //.
@@ -461,20 +429,18 @@ suff : exists l, cluster (sol q @ +oo%R) `<=` V @^-1` [set l].
   apply: (@cvg_lim _ _ _ (at_right _)) => // A A0.
   rewrite !near_simpl; near=> h.
   rewrite /= sol0 addr0.
-  rewrite [X in sol p X](_ : _ = h); last first.
-    by rewrite /GRing.scale/= mulr1.
+  rewrite [X in sol p X](_ : _ = h); last by rewrite scaler1.
   rewrite Vpliml//.
     by rewrite Vpliml // subrr scaler0; apply: nbhs_singleton.
-  by apply: invariant_plim => //; apply: ltW; near: h; exists 1%R => //=.
+  by apply: invariant_plim => //; apply: ltW; near: h; exists 1%R.
 suff cvVsol : cvg (V \o sol q @ +oo%R).
-  exists (lim (V \o sol q @ +oo%R)); apply: (c0_cvg_cst_on_plim Vcont)=> //.
+  exists (lim (V \o sol q @ +oo%R)); apply: (c0_cvg_cst_on_plim Vcont) => //.
   exact: compact_closed.
 apply: nincr_lb_cvg; last first.
   have: compact (V @` K) by apply: continuous_on_compact.
   move=> /compact_bounded [N imVltN].
   exists (- (N + 2))%R=> _ [t tge0 <-].
-  suff : (`|(V \o sol q) t| < N + 2)%R.
-    by rewrite ltr_norml => /andP [].
+  suff : (`|(V \o sol q) t| < N + 2)%R by rewrite ltr_norml => /andP[].
   rewrite (@le_lt_trans _ _ (N + 1)%R)// ?ltrD2l ?ltr1n//.
   by apply: imVltN.2; [rewrite ltrDl|apply/imageP/Kinvar].
 move=> s t /andP [sge0 slet].
@@ -483,14 +449,15 @@ apply: (@ler0_derive1_le_cc _ _ s t); first 2 last.
   rewrite inE/= in_itv/= => /andP[sx xt].
   have := Vsol_drvbl _ _ Kq (le_trans sge0 sx).
   move/derivable1_diffP/differentiable_continuous.
-  by apply.
+  exact.
   by rewrite in_itv/= slet lexx.
   by rewrite in_itv/= lexx slet.
   by [].
   move=> r rst.
   apply: Vsol_drvbl => //; apply: le_trans sge0 _.
   by rewrite (itvP rst).
-move=> r rst; have rge0 : (0 <= r)%R by apply: le_trans sge0 _; rewrite (itvP rst).
+move=> r rst.
+have rge0 : (0 <= r)%R by apply: le_trans sge0 _; rewrite (itvP rst).
 suff -> : derive1 (V \o sol q) r = derive1 (V \o (sol (sol q r))) 0.
   exact/Vsol'le0/Kinvar.
 rewrite derive1E /derive cvg_at_rightE; last exact: Vsol_drvbl.
@@ -499,12 +466,11 @@ rewrite derive1E /derive cvg_at_rightE; last first.
 congr (lim _); rewrite predeqE /= nbhs_filterE => A; split.
   move=> [_/posnumP[e] Ae]; exists e%:num%R=> //= x xe xgt0.
   rewrite sol0/=.
-  rewrite addr0 -solD //; [by apply: Ae|].
-  by rewrite /GRing.scale/= mulr1 ltW.
+  rewrite addr0 -solD //; [exact: Ae|].
+  by rewrite scaler1 ltW.
 move=> [_/posnumP[e] Ae]; exists e%:num%R => //= x xe xgt0.
 have /Ae - /(_ xe) := xgt0.
-rewrite sol0/= addr0 -solD //.
-by rewrite /GRing.scale/= mulr1 ltW.
+by rewrite sol0/= addr0 -solD// scaler1 ltW.
 Unshelve. all: by end_near. Qed.
 
 Lemma cvg_to_limS (A : set U) : compact A -> is_invariant A ->
@@ -513,8 +479,9 @@ Proof.
 move=> Aco Ainvar p Ap B [_/posnumP[e] limSeB].
 apply: (cvg_to_plim _ Aco).
   exists 0%R; split => //.
-  by move=> _/posnumP[?]; apply: Ainvar.
-by exists e%:num%R=> //= q [r plimr re_q]; apply: limSeB; exists r => //; exists p.
+  by move=> _/posnumP[?]; exact: Ainvar.
+exists e%:num%R=> //= q [r plimr re_q].
+by apply: limSeB; exists r => //; exists p.
 Qed.
 
 End DifferentialSystem.

--- a/lasalle.v
+++ b/lasalle.v
@@ -1,8 +1,8 @@
 From HB Require Import structures.
 From mathcomp Require Import ssreflect ssrfun ssrbool ssrnat eqtype choice seq.
-From mathcomp Require Import order.
+From mathcomp Require Import order interval_inference.
 From mathcomp Require Import fintype bigop ssralg ssrnum finmap interval ssrint.
-From mathcomp Require Import boolp reals Rstruct classical_sets signed functions.
+From mathcomp Require Import boolp reals classical_sets functions.
 From mathcomp Require Import topology normedtype landau derive.
 
 Set Implicit Arguments.
@@ -75,20 +75,20 @@ Proof.
 move=> FF FA; rewrite compact_In0 => Aco e egt0.
 set B := ball_set (cluster F) e.
 have Fn0 : F !=set0 by exists A.
-have : A `&` (cluster F `\` B^°) = set0.
-  suff -> : cluster F `\` B^° = set0 by rewrite setI0.
+have : A `&` (cluster F `\` B°) = set0.
+  suff -> : cluster F `\` B° = set0 by rewrite setI0.
   rewrite setD_eq0 => p clFp.
   by rewrite /interior -nbhs_ballE; exists e => // ??; exists p.
 rewrite clusterE.
 rewrite -[_ `\` _]bigcapIl // setIC.
 rewrite -bigcapIl // => IFBoA0.
-set f := fun C => closure C `&` ~` B^° `&` A.
+set f := fun C => closure C `&` ~` B° `&` A.
 have [G sGF IGBoA0] : exists2 G : {fset (set U)},
   {subset G <= F} & \bigcap_(C in [set C | C \in G]) f C = set0.
   have {}IFBoA0 : ~ (\bigcap_(C in F) f C !=set0).
     by move=> [p IFBoAp]; rewrite -[False]/(set0 p) -IFBoA0.
   have /Aco : closed_fam_of A F f.
-    exists (fun C => closure C `&` ~` B^°).
+    exists (fun C => closure C `&` ~` B°).
       move=> C _; apply: closedI (@closed_closure _ _) _.
       by rewrite closedC; exact/open_interior.
     by move=> ? _; rewrite setIC.
@@ -99,10 +99,10 @@ have Gn0 : [set C | C \in G] !=set0.
   apply: contrapT => /asboolPn /forallp_asboolPn G0.
   by rewrite -[False]/(@set0 U point) -IGBoA0 => ? /G0.
 move: IGBoA0; have -> : \bigcap_(C in [set C | C \in G]) f C =
-  \bigcap_(C in [set C | C \in G]) (A `&` closure C `&` ~` B^°).
+  \bigcap_(C in [set C | C \in G]) (A `&` closure C `&` ~` B°).
   by rewrite predeqE => a; split=> IGBoAa ? /IGBoAa [[]].
 rewrite bigcapIl // setD_eq0 => sIGABo.
-suff : F B^° by apply: filterS => ?; apply: nbhs_singleton.
+suff : F B° by apply: filterS => ?; apply: nbhs_singleton.
 apply: filterS sIGABo _; apply: filter_bigI => C /sGF; rewrite in_setE => FC.
 by apply: filterI FA _; apply: filterS (@subset_closure _ C) _.
 Qed.
@@ -330,7 +330,7 @@ move: tge0; rewrite le_eqVlt orbC => /orP [tgt0|/eqP teq0].
     rewrite derive_val addrC addrA [(_ s + _)%R]addrC subrr add0r.
     near: s.
     case: e => /= e.
-    rewrite eq_sym -lt_neqAle.
+    rewrite /Itv.num_sem/= num_real/= in_itv/= andbT.
     move: e.
     apply/(eqoP (nbhs_filter_on (0%R : R))).
     (* 0.3.6: 'o_[filter of nbhs 0%R] id  = 'o_(nbhs_filter_on 0%R) id  *)
@@ -351,7 +351,7 @@ have := dsol; rewrite funeqE => /(_ s) /=; rewrite [(_%:A)%R]mulr1 =>->.
 rewrite -{1}teq0 derive_val; case: (lerP 0 s) => [le0s|lts0].
   rewrite addrC addrA [(_ s + _)%R]addrC subrr add0r; near: s.
   case: e => /= e.
-  rewrite eq_sym -lt_neqAle.
+  rewrite /Itv.num_sem num_real in_itv/= andbT.
   move: e.
   apply/(eqoP (nbhs_filter_on (0%R : R))).
 (* 0.3.6:
@@ -365,7 +365,7 @@ rewrite scaleNr opprK addrC addKr -[in X in (_ <= X)%R]normrN; near: s.
 rewrite !near_simpl.
 rewrite -(nearN (fun x : R^o => `|_ x| <= e%:num * `|x|%R))%R.
 case: e => /= e.
-rewrite eq_sym -lt_neqAle => e0.
+rewrite /Itv.num_sem num_real in_itv/= andbT => e0.
 near=> x.
 set u := (X in `|X x|%R).
 near: x.
@@ -478,12 +478,15 @@ apply: nincr_lb_cvg; last first.
   rewrite (@le_lt_trans _ _ (N + 1)%R)// ?ltrD2l ?ltr1n//.
   by apply: imVltN.2; [rewrite ltrDl|apply/imageP/Kinvar].
 move=> s t /andP [sge0 slet].
-apply: ler0_derive1_nincr (lexx _) slet (lexx _); first 2 last.
+apply: (@ler0_derive1_le_cc _ _ s t); first 2 last.
   apply: continuous_in_subspaceT => x.
   rewrite inE/= in_itv/= => /andP[sx xt].
   have := Vsol_drvbl _ _ Kq (le_trans sge0 sx).
   move/derivable1_diffP/differentiable_continuous.
   by apply.
+  by rewrite in_itv/= slet lexx.
+  by rewrite in_itv/= lexx slet.
+  by [].
   move=> r rst.
   apply: Vsol_drvbl => //; apply: le_trans sge0 _.
   by rewrite (itvP rst).

--- a/lasalle.v
+++ b/lasalle.v
@@ -11,6 +11,9 @@ Import GRing.Theory Num.Def Num.Theory Order.POrderTheory Order.TotalTheory.
 
 Local Open Scope classical_set_scope.
 
+Lemma mul2r (R : ringType) (x : R) : (2 * x = x + x)%R.
+Proof. by rewrite -mulr2n mulr_natl. Qed.
+
 Section pseudoMetricType_numDomainType.
 Context {R : numDomainType} {M : pseudoMetricType R}.
 
@@ -350,7 +353,9 @@ rewrite -{1}teq0 derive_val; case: (lerP 0 s) => [le0s|lts0].
   'o_[filter of nbhs 0%R] id  = 'o_(nbhs_filter_on 0%R) id *)
   by [].
 rewrite !opprD oppox /cst /= addrACA -[(- _ : _ -> _)%R _]/(- _)%R !addrA.
-rewrite mulr2n scalerDl scale1r -[(_ - _ - sol _ _)%R]addrA -opprD subrr sub0r.
+rewrite [X in (X *: _)%R](_ : _ = (1 + 1)%R); last first.
+  done.
+rewrite scalerDl scale1r -[(_ - _ - sol _ _)%R]addrA -opprD subrr sub0r.
 rewrite scaleNr opprK addrC addKr -[in X in (_ <= X)%R]normrN; near: s.
 rewrite !near_simpl.
 rewrite -(nearN (fun x : R^o => `|_ x| <= e%:num * `|x|%R))%R.
@@ -446,7 +451,7 @@ suff : exists l, cluster (sol q @ +oo%R) `<=` V @^-1` [set l].
   move=> [l Vpliml]/=; rewrite derive1E /derive cvg_at_rightE; last first.
     apply: Vsol_drvbl => //; apply: compact_closed => //.
     exact: sub_plim_clos_invar plimp.
-  apply: (@cvg_map_lim _ _ _ (at_right _)) => // A A0.
+  apply: (@cvg_lim _ _ _ (at_right _)) => // A A0.
     rewrite -closeEnbhs.
      move/close_eq; apply.
      exact: Rhausdorff.
@@ -470,7 +475,7 @@ apply: nincr_lb_cvg; last first.
   by apply: imVltN.2; [rewrite ltr_addl|apply/imageP/Kinvar].
 move=> s t /andP [sge0 slet].
 apply: ler0_derive1_nincr (lexx _) slet (lexx _); first 2 last.
-  apply: continuous_subspaceT => x.
+  apply: continuous_in_subspaceT => x.
   rewrite inE/= in_itv/= => /andP[sx xt].
   have := Vsol_drvbl _ _ Kq (le_trans sge0 sx).
   move/derivable1_diffP/differentiable_continuous.

--- a/lasalle.v
+++ b/lasalle.v
@@ -1,7 +1,7 @@
 From mathcomp Require Import ssreflect ssrfun ssrbool ssrnat eqtype choice seq.
 From mathcomp Require Import order.
 From mathcomp Require Import fintype bigop ssralg ssrnum finmap interval ssrint.
-From mathcomp Require Import boolp reals Rstruct classical_sets posnum functions.
+From mathcomp Require Import boolp reals Rstruct classical_sets signed functions.
 From mathcomp Require Import topology normedtype landau derive.
 
 Set Implicit Arguments.

--- a/lasalle.v
+++ b/lasalle.v
@@ -20,7 +20,7 @@ Context {R : numDomainType} {M : pseudoMetricType R}.
 
 Definition ball_set (A : set M) e := \bigcup_(p in A) ball p e.
 
-HB.instance Definition _ := isPointed.Build (set M) [set point].
+(*HB.instance Definition _ := isPointed.Build (set M) [set point].*)
 
 HB.instance Definition _ := isFiltered.Build M (set M) (nbhs_ball_ ball_set).
 
@@ -28,7 +28,7 @@ End pseudoMetricType_numDomainType.
 
 Section PositiveLimitingSet.
 Variable R : realFieldType.
-Variable U : pseudoMetricType R.
+Variable U : pseudoPMetricType R.
 
 Definition pos_limit_set (y : R -> U) :=
   \bigcap_(eps in [set e | 0 < e]%R) \bigcap_(T in [set T | 0 < T]%R)
@@ -437,7 +437,7 @@ rewrite distrC ger0_norm.
   rewrite ltrBlDl.
   by apply: le_lt_trans ltftinfe; apply: fnincr; rewrite tge0 (ltW ltts).
 rewrite subr_ge0.
-apply: inf_lb => //.
+apply: inf_lbound => //.
   by case: imf_inf.
 rewrite in_setE; apply: imageP.
 by apply: ltW; apply: le_lt_trans ltts.

--- a/lasalle.v
+++ b/lasalle.v
@@ -387,7 +387,7 @@ Lemma invariant_plim p : K p -> is_invariant (cluster (sol p @ +oo%R)).
 Proof.
 move=> Kp q plim_q t0 t0_ge0 A B [M].
 wlog Mge0 : M / (0 <= M)%R => [sufMge0|] [Mreal solpMinfty_A].
-  apply: (sufMge0 (maxr 0%R M)); first by rewrite le_maxr lexx.
+  apply: (sufMge0 (maxr 0%R M)); first by rewrite le_max lexx.
   split.
     by rewrite max_real// real0.
   by move=> x; rewrite gt_max => /andP[_]; apply: solpMinfty_A.
@@ -395,10 +395,9 @@ have Kq : K q.
   apply: compact_closed => //.
   move=> C qC.
   move: plim_q; apply => //.
-  exists 0%R; split.
-    by rewrite real0.
+  exists 0%R; split => //.
   move=> t /ltW tge0.
-  by apply: Kinvar.
+  exact: Kinvar.
 move=> /(sol_cont Kq) /plim_q q_Bsolt0.
 have /q_Bsolt0 [_ [[[t tgtM <-] _]]] : (sol p @ +oo%R) (sol p @` (> M)%R `&` A).
   by exists M; split => // => t tgtM; split; [apply: imageP|apply: solpMinfty_A].
@@ -437,7 +436,10 @@ rewrite /ball/=.
 rewrite distrC ger0_norm.
   rewrite ltrBlDl.
   by apply: le_lt_trans ltftinfe; apply: fnincr; rewrite tge0 (ltW ltts).
-rewrite subr_ge0 inf_lower_bound // in_setE; apply: imageP.
+rewrite subr_ge0.
+apply: inf_lb => //.
+  by case: imf_inf.
+rewrite in_setE; apply: imageP.
 by apply: ltW; apply: le_lt_trans ltts.
 Qed.
 

--- a/lasalle.v
+++ b/lasalle.v
@@ -1,3 +1,4 @@
+From HB Require Import structures.
 From mathcomp Require Import ssreflect ssrfun ssrbool ssrnat eqtype choice seq.
 From mathcomp Require Import order.
 From mathcomp Require Import fintype bigop ssralg ssrnum finmap interval ssrint.
@@ -18,8 +19,10 @@ Section pseudoMetricType_numDomainType.
 Context {R : numDomainType} {M : pseudoMetricType R}.
 
 Definition ball_set (A : set M) e := \bigcup_(p in A) ball p e.
-Canonical set_filter_source :=
-  @Filtered.Source Prop _ M (fun A => nbhs_ball_ ball_set A).
+
+HB.instance Definition _ := isPointed.Build (set M) [set point].
+
+HB.instance Definition _ := isFiltered.Build M (set M) (nbhs_ball_ ball_set).
 
 End pseudoMetricType_numDomainType.
 
@@ -41,8 +44,8 @@ rewrite predeqE => p; split.
     by have [t [/ygtM_A Ayt /pe_B Byt]] := plim_p _ egt0 _ Mgt0; exists (y t).
   move=> /(_ (maxr M 1%R)) []; last by move=> q ?; exists q.
       by rewrite max_real// real1.
-    by move=> ?; rewrite lt_maxl => /andP [/ygtM_A].
-  by rewrite lt_maxr orbC ltr01.
+    by move=> ?; rewrite gt_max => /andP [/ygtM_A].
+  by rewrite lt_max orbC ltr01.
 move=> clyp e egt0 T Tgt0.
 have [] := clyp (y @` ltr T) (ball p e).
   exists T; split => //.
@@ -53,7 +56,7 @@ by move=> _ [[t ? <-] ?]; exists t.
 Qed.
 
 (* mathcomp/analysis issue: should be inferred *)
-Instance infty_proper : @ProperFilter R [filter of +oo%R].
+Instance infty_proper : @ProperFilter R +oo%R.
 Proof. exact: proper_pinfty_nbhs. Qed.
 
 Lemma plimn0 (y : R -> U) (A : set U) :
@@ -144,9 +147,9 @@ Proof. by move=> syRpA p ypp B /ypp; apply; apply: sub_image_at_infty. Qed.
 
 (* to mathcomp/analysis ? *)
 Definition continuous_on (T U : topologicalType) (A : set T) (f : T -> U) :=
-  forall p, A p -> f @ (within A [filter of p]) --> f p.
+  forall p : T, A p -> f @ (within A (nbhs p)) --> f p.
 
-Lemma map_sub_cluster (S T : topologicalType) (F : set (set S)) (f : S -> T)
+Lemma map_sub_cluster (S T : topologicalType) (F : set_system S) (f : S -> T)
   (A : set S) : Filter F -> continuous_on A f -> F A -> closed A ->
   f @` (cluster F) `<=` cluster (f @ F).
 Proof.
@@ -176,8 +179,8 @@ Proof.
 rewrite /bounded_set => - [N [Nreal ybndN]].
 wlog Ngt0 : N Nreal ybndN / (0 < N)%R.
   move=> bnd_plim; apply: (bnd_plim (maxr N 1%R)); last first.
-    by rewrite lt_maxr orbC ltr01.
-  by move=> ?; rewrite lt_maxl => /andP [/ybndN].
+    by rewrite lt_max orbC ltr01.
+  by move=> ?; rewrite gt_max => /andP [/ybndN].
   by rewrite max_real// real1.
 rewrite /bounded_set.
 red.
@@ -186,11 +189,11 @@ have [] := plimp (y @` (>= 0)%R) (ball_ Num.norm p (PosNum Ngt0)%:num).
 - exact: sub_image_at_infty.
 - exact: nbhs_ball_norm.
 move=> _ [[t tge0 <-] pN_yt]; rewrite -[p](subrK (y t)).
-apply: (le_trans (ler_norm_add _ _)).
-rewrite -ler_subr_addr.
+apply: (le_trans (ler_normD _ _)).
+rewrite -lerBrDr.
 apply/ltW; apply: lt_le_trans pN_yt _.
-rewrite ler_subr_addr addrC -ler_subr_addr; apply: ybndN; last by exists t.
-rewrite ltr_subr_addr; near: M; exists (N + N)%R.
+rewrite lerBrDr addrC -lerBrDr; apply: ybndN; last by exists t.
+rewrite ltrBrDr; near: M; exists (N + N)%R.
 split => //.
 by rewrite realD.
 Unshelve. all: by end_near. Qed.
@@ -302,7 +305,9 @@ suff dshift : (shift_sol p t0) \o shift t = (cst (shift_sol p t0 t) +
       abstract: dshiftE.
       have lin_scal : linear (fun h : R^o => h *: F (shift_sol p t0 t))%R.
         by move=> ???; rewrite scalerDl scalerA.
-      have ->: (fun h : R^o => h *: F (shift_sol p t0 t))%R = Linear lin_scal by [].
+      pose glM := GRing.isLinear.Build _ _ _ _ _ lin_scal.
+      pose gL : {linear R^o -> U} := HB.pack ( *:%R^~ (F (shift_sol p t0 t))) glM.
+      have ->: (fun h : R^o => h *: F (shift_sol p t0 t))%R = gL by [].
       apply/esym.
       apply: diff_unique; first exact: scalel_continuous.
       apply/eqaddoE; rewrite dshift.
@@ -331,7 +336,7 @@ move: tge0; rewrite le_eqVlt orbC => /orP [tgt0|/eqP teq0].
     (* 0.3.6: 'o_[filter of nbhs 0%R] id  = 'o_(nbhs_filter_on 0%R) id  *)
     by [].
   near: s; exists t => // s; rewrite /ball_ /= => ltst.
-  rewrite -ler_subl_addl sub0r; apply/ltW; apply: le_lt_trans ltst.
+  rewrite -lerBlDl sub0r; apply/ltW; apply: le_lt_trans ltst.
   by rewrite sub0r ler_norm.
 rewrite -teq0.
 rewrite shift0.
@@ -385,7 +390,7 @@ wlog Mge0 : M / (0 <= M)%R => [sufMge0|] [Mreal solpMinfty_A].
   apply: (sufMge0 (maxr 0%R M)); first by rewrite le_maxr lexx.
   split.
     by rewrite max_real// real0.
-  by move=> x; rewrite lt_maxl => /andP[_]; apply: solpMinfty_A.
+  by move=> x; rewrite gt_max => /andP[_]; apply: solpMinfty_A.
 have Kq : K q.
   apply: compact_closed => //.
   move=> C qC.
@@ -400,7 +405,7 @@ have /q_Bsolt0 [_ [[[t tgtM <-] _]]] : (sol p @ +oo%R) (sol p @` (> M)%R `&` A).
 have tge0 : (0 <= t)%R by apply/ltW; apply: le_lt_trans tgtM.
 have Ksolpt : K (sol p t) by apply: Kinvar.
 move=> /(_ Ksolpt) /=; rewrite -solD // => Bsolpt0t; exists (sol p (t0 + t)).
-by split=> //; apply/solpMinfty_A/ltr_paddl.
+by split=> //; apply/solpMinfty_A/ltr_wpDl.
 Qed.
 
 Definition limS (A : set U) := \bigcup_(q in A) cluster (sol q @ +oo%R).
@@ -430,7 +435,7 @@ rewrite in_setE => -[t tge0 <-] ltftinfe; exists t; split.
 move=> s ltts; apply: infe_A.
 rewrite /ball/=.
 rewrite distrC ger0_norm.
-  rewrite ltr_subl_addl.
+  rewrite ltrBlDl.
   by apply: le_lt_trans ltftinfe; apply: fnincr; rewrite tge0 (ltW ltts).
 rewrite subr_ge0 inf_lower_bound // in_setE; apply: imageP.
 by apply: ltW; apply: le_lt_trans ltts.
@@ -452,9 +457,6 @@ suff : exists l, cluster (sol q @ +oo%R) `<=` V @^-1` [set l].
     apply: Vsol_drvbl => //; apply: compact_closed => //.
     exact: sub_plim_clos_invar plimp.
   apply: (@cvg_lim _ _ _ (at_right _)) => // A A0.
-    rewrite -closeEnbhs.
-     move/close_eq; apply.
-     exact: Rhausdorff.
   rewrite !near_simpl; near=> h.
   rewrite /= sol0 addr0.
   rewrite [X in sol p X](_ : _ = h); last first.
@@ -471,8 +473,8 @@ apply: nincr_lb_cvg; last first.
   exists (- (N + 2))%R=> _ [t tge0 <-].
   suff : (`|(V \o sol q) t| < N + 2)%R.
     by rewrite ltr_norml => /andP [].
-  rewrite (@le_lt_trans _ _ (N + 1)%R)// ?ltr_add2l ?ltr1n//.
-  by apply: imVltN.2; [rewrite ltr_addl|apply/imageP/Kinvar].
+  rewrite (@le_lt_trans _ _ (N + 1)%R)// ?ltrD2l ?ltr1n//.
+  by apply: imVltN.2; [rewrite ltrDl|apply/imageP/Kinvar].
 move=> s t /andP [sge0 slet].
 apply: ler0_derive1_nincr (lexx _) slet (lexx _); first 2 last.
   apply: continuous_in_subspaceT => x.
@@ -501,7 +503,7 @@ by rewrite /GRing.scale/= mulr1 ltW.
 Unshelve. all: by end_near. Qed.
 
 Lemma cvg_to_limS (A : set U) : compact A -> is_invariant A ->
-  forall p, A p -> sol p @ +oo%R --> (limS A : set [pseudoMetricType _ of U]).
+  forall p, A p -> sol p @ +oo%R --> (limS A : set U).
 Proof.
 move=> Aco Ainvar p Ap B [_/posnumP[e] limSeB].
 apply: (cvg_to_plim _ Aco).

--- a/lasalle.v
+++ b/lasalle.v
@@ -1,56 +1,71 @@
 Require Import Reals.
 From mathcomp Require Import ssreflect ssrfun ssrbool ssrnat eqtype choice seq.
+From mathcomp Require Import order.
 From mathcomp Require Import fintype bigop ssralg ssrnum finmap interval ssrint.
-From mathcomp Require Import boolp reals Rstruct Rbar classical_sets posnum.
+From mathcomp Require Import boolp reals Rstruct classical_sets posnum.
 From mathcomp Require Import topology normedtype landau derive.
 
 Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.
-Import GRing.Theory Num.Def Num.Theory.
+Import GRing.Theory Num.Def Num.Theory Order.POrderTheory Order.TotalTheory.
 
 Local Open Scope classical_set_scope.
 
-Section PositiveLimitingSet.
+Section pseudoMetricType_numDomainType.
+Context {R : numDomainType} {M : pseudoMetricType R}.
 
-Variable U : uniformType.
+Definition ball_set (A : set M) e := \bigcup_(p in A) ball p e.
+Canonical set_filter_source :=
+  @Filtered.Source Prop _ M (fun A => nbhs_ball_ ball_set A).
+
+End pseudoMetricType_numDomainType.
+
+Section PositiveLimitingSet.
+Variable R : realFieldType.
+Variable U : pseudoMetricType R.
 
 Definition pos_limit_set (y : R -> U) :=
-  \bigcap_(eps in [set e | 0 < e]) \bigcap_(T in [set T | 0 < T])
+  \bigcap_(eps in [set e | 0 < e]%R) \bigcap_(T in [set T | 0 < T]%R)
     [set p | ltr T `&` (y @^-1` ball p eps) !=set0].
 
 Lemma plim_cluster (y : R -> U) :
-  pos_limit_set y = cluster (y @ +oo).
+  pos_limit_set y = cluster (y @ +oo%R).
 Proof.
 rewrite predeqE => p; split.
-  move=> plim_p A B [M ygtM_A] /locallyP [e egt0 pe_B].
-  wlog Mgt0 : M ygtM_A / 0 < M; last first.
+  move=> plim_p A B [M [Mreal ygtM_A]].
+  move=> /nbhs_ballP [e egt0 pe_B].
+  wlog Mgt0 : M Mreal ygtM_A / (0 < M)%R; last first.
     by have [t [/ygtM_A Ayt /pe_B Byt]] := plim_p _ egt0 _ Mgt0; exists (y t).
-  move=> /(_ (maxr M 1)) []; last by move=> q ?; exists q.
-    by move=> ?; rewrite ltr_maxl => /andP [/ygtM_A].
-  by rewrite ltr_maxr orbC ltr01.
+  move=> /(_ (maxr M 1%R)) []; last by move=> q ?; exists q.
+      by rewrite maxr_real.
+    by move=> ?; rewrite lt_maxl => /andP [/ygtM_A].
+  by rewrite lt_maxr orbC ltr01.
 move=> clyp e egt0 T Tgt0.
-have [] := clyp (y @` ltr T) (ball p e); first by exists T; apply: imageP.
-  by rewrite -locally_ballE; exists e.
+have [] := clyp (y @` ltr T) (ball p e).
+  exists T; split => //.
+    by rewrite realE (ltW Tgt0).
+  by apply: imageP.
+  by rewrite -nbhs_ballE; exists e.
 by move=> _ [[t ? <-] ?]; exists t.
 Qed.
 
 (* mathcomp/analysis issue: should be inferred *)
-Instance infty_proper : ProperFilter [filter of +oo].
-Proof. exact: Rbar_locally_filter. Qed.
+Instance infty_proper : @ProperFilter R [filter of +oo%R].
+Proof. exact: proper_pinfty_nbhs. Qed.
 
-Lemma plimn0 y (A : set U) :
-  compact A -> (y @ +oo) A -> cluster (y @ +oo) !=set0.
+Lemma plimn0 (y : R -> U) (A : set U) :
+  compact A -> (y @ +oo%R) A -> cluster (y @ +oo%R) !=set0.
 Proof. by move=> Aco /Aco [p []]; exists p. Qed.
 
-Lemma closed_plim (y : R -> U) : closed (cluster (y @ +oo)).
+Lemma closed_plim (y : R -> U) : closed (cluster (y @ +oo%R)).
 Proof.
 by rewrite clusterE; apply: closed_bigI => ??; apply: closed_closure.
 Qed.
 
 Lemma filter_cluster (F : set (set U)) (A : set U) :
   ProperFilter F -> F A -> compact A ->
-  forall e, 0 < e -> F (ball_set (cluster F) e).
+  forall e, (0 < e)%R -> F (ball_set (cluster F) e).
 Proof.
 move=> FF FA; rewrite compact_In0 => Aco e egt0.
 set B := ball_set (cluster F) e.
@@ -58,7 +73,7 @@ have Fn0 : F !=set0 by exists A.
 have : A `&` (cluster F `\` B^°) = set0.
   suff -> : cluster F `\` B^° = set0 by rewrite setI0.
   rewrite setD_eq0 => p clFp.
-  by rewrite /interior -locally_ballE; exists e => // ??; exists p.
+  by rewrite /interior -nbhs_ballE; exists e => // ??; exists p.
 rewrite clusterE [_ `\` _]setI_bigcapl // setIC setI_bigcapl // => IFBoA0.
 set f := fun C => closure C `&` ~` B^° `&` A.
 have [G sGF IGBoA0] : exists2 G : {fset (set U)},
@@ -80,13 +95,13 @@ move: IGBoA0; have -> : \bigcap_(C in [set C | C \in G]) f C =
   \bigcap_(C in [set C | C \in G]) (A `&` closure C `&` ~` B^°).
   by rewrite predeqE => a; split=> IGBoAa ? /IGBoAa [[]].
 rewrite -setI_bigcapl // setD_eq0 => sIGABo.
-suff : F B^° by apply: filterS => ?; apply: locally_singleton.
+suff : F B^° by apply: filterS => ?; apply: nbhs_singleton.
 apply: filterS sIGABo _; apply: filter_bigI => C /sGF; rewrite in_setE => FC.
 by apply: filterI FA _; apply: filterS (@subset_closure _ C) _.
 Qed.
 
 Lemma cvg_to_plim (y : R -> U) (A : set U) :
-  (y @ +oo) A -> compact A -> y @ +oo --> cluster (y @ +oo).
+  (y @ +oo%R) A -> compact A -> y @ +oo%R --> cluster (y @ +oo%R).
 Proof.
 move=> yinftyA coA B [e egt0 scleB].
 by apply: filterS scleB _; apply: filter_cluster coA _ egt0.
@@ -111,16 +126,22 @@ Qed.
 (* by exists p => // C D yinftyC; apply/plimnBp; apply: flim_within yinftyC. *)
 (* Qed. *)
 
-Lemma sub_image_at_infty y (A : set U) : y @` (>= 0) `<=` A -> (y @ +oo) A.
-Proof. by move=> syRpA; exists 0 => t tgt0; apply/syRpA/imageP/ltrW. Qed.
+Lemma sub_image_at_infty (y : R -> U) (A : set U) : y @` (>= 0)%R `<=` A -> (y @ +oo%R) A.
+Proof.
+move=> syRpA; exists 0%R; split.
+  by rewrite realE lexx.
+move=> t tgt0.
+exact/syRpA/imageP/ltW.
+Qed.
 
-Lemma sub_plim_clos_invar y (A : set U) :
-  y @` (>= 0) `<=` A -> cluster (y @ +oo) `<=` closure A.
+Lemma sub_plim_clos_invar (y : R -> U) (A : set U) :
+  y @` (>= 0)%R `<=` A -> cluster (y @ +oo%R) `<=` closure A.
 Proof. by move=> syRpA p ypp B /ypp; apply; apply: sub_image_at_infty. Qed.
 
 (* to mathcomp/analysis ? *)
 Definition continuous_on (T U : topologicalType) (A : set T) (f : T -> U) :=
   forall p, A p -> f @ (within A [filter of p]) --> f p.
+
 Lemma map_sub_cluster (S T : topologicalType) (F : set (set S)) (f : S -> T)
   (A : set S) : Filter F -> continuous_on A f -> F A -> closed A ->
   f @` (cluster F) `<=` cluster (f @ F).
@@ -132,36 +153,41 @@ suff /clFp /(_ fp_C) [q [[Aq ?] /(_ Aq)]] : F (A `&` f @^-1` B) by exists (f q).
 exact: filterI.
 Qed.
 
-Lemma c0_cvg_cst_on_plim A y (V : U -> R) (l : R) :
-  continuous_on A V -> V \o y @ +oo --> l ->
-  closed A -> y @` (>= 0) `<=` A -> cluster (y @ +oo) `<=` V @^-1` [set l].
+Lemma c0_cvg_cst_on_plim A (y : R -> U) (V : U -> R^o) (l : R^o) :
+  continuous_on A V -> V \o y @ +oo%R --> l ->
+  closed A -> y @` (>= 0)%R `<=` A -> cluster (y @ +oo%R) `<=` V @^-1` [set l].
 Proof.
 move=> Vcont Vypl Acl syRpA p plimp.
-have Aypinfty : (y @ +oo) A by apply: sub_image_at_infty.
-have : (V @` cluster (y @ +oo)) (V p) by exists p.
+have Aypinfty : (y @ +oo%R) A by apply: sub_image_at_infty.
+have : (V @` cluster (y @ +oo%R)) (V p) by exists p.
 move=> /(map_sub_cluster _ Vcont Aypinfty Acl).
-by move=> /(flim_cluster Vypl) /Rhausdorff ->.
+by move=> /(cvg_cluster Vypl) /Rhausdorff ->.
 Qed.
 
 End PositiveLimitingSet.
 
-Lemma bounded_plim (K : absRingType) (V : normedModType K) (y : R -> V) :
-  bounded (y @` (>= 0)) -> bounded (cluster (y @ +oo)).
+Lemma bounded_plim (K : realFieldType) (V : normedModType K) (y : K -> V) :
+  bounded_set (y @` (>= 0)%R) -> bounded_set (cluster (y @ +oo%R)).
 Proof.
-rewrite /bounded => - [N ybndN].
-wlog Ngt0 : N ybndN / 0 < N.
-  move=> bnd_plim; apply: (bnd_plim (maxr N 1)); last first.
-    by rewrite ltr_maxr orbC ltr01.
-  by move=> ?; rewrite ltr_maxl => /andP [/ybndN].
+rewrite /bounded => - [N [Nreal ybndN]].
+wlog Ngt0 : N Nreal ybndN / (0 < N)%R.
+  move=> bnd_plim; apply: (bnd_plim (maxr N 1%R)); last first.
+    by rewrite lt_maxr orbC ltr01.
+  by move=> ?; rewrite lt_maxl => /andP [/ybndN].
+  by rewrite maxr_real.
+red.
 near=> M => p plimp.
-have [] := plimp (y @` (>= 0)) (ball_ norm p (PosNum Ngt0)%:num).
+have [] := plimp (y @` (>= 0)%R) (ball_ Num.norm p (PosNum Ngt0)%:num).
 - exact: sub_image_at_infty.
-- exact: locally_ball_norm.
+- exact: nbhs_ball_norm.
 move=> _ [[t tge0 <-] pN_yt]; rewrite -[p](subrK (y t)).
-apply: ler_lt_trans (ler_normm_add _ _) _.
-rewrite -ltr_subr_addr; apply: ltr_trans pN_yt _.
-rewrite ltr_subr_addr addrC -ltr_subr_addr; apply: ybndN; last by exists t.
-by rewrite ltr_subr_addr; near: M; exists (N + N).
+apply: (le_trans (ler_norm_add _ _)).
+rewrite -ler_subr_addr.
+apply/ltW; apply: lt_le_trans pN_yt _.
+rewrite ler_subr_addr addrC -ler_subr_addr; apply: ybndN; last by exists t.
+rewrite ltr_subr_addr; near: M; exists (N + N)%R.
+split => //.
+by rewrite realD.
 Grab Existential Variables. all: end_near. Qed.
 
 Lemma continuous_on_compact (S T : topologicalType) (f : S -> T) (A : set S) :
@@ -173,7 +199,8 @@ have GF : ProperFilter G.
     move=> C1 C2 F1 F2; exists (C1 `&` C2); first exact: filterI.
     by move=> ?[?[]]; split; split.
   by move=> C /(filterI FfA) /filter_ex [_ [[p ? <-]]]; eexists p.
-case: Aco; first by exists (f @` A) => // ? [].
+move: Aco => /(_ G GF)[].
+  by exists (f @` A) => // ? [].
 move=> p [Ap clsGp]; exists (f p); split; first exact/imageP.
 move=> B C FB /(fcont _ Ap) /= p_Cf.
 have : G (A `&` f @^-1` B) by exists B.
@@ -183,14 +210,14 @@ Qed.
 Section DifferentialSystem.
 
 Variable U : normedModType R.
-Let hU : hausdorff U := @normedModType_hausdorff _ U.
+Let hU : hausdorff U := @norm_hausdorff _ U.
 
 (* function defining the differential system *)
 Variable F : U -> U.
 
-Definition is_sol (y : R^o -> U) :=
-  (forall t, t < 0 -> y t = 2 *: (y 0) - (y (- t))) /\
-  forall t, 0 <= t -> is_derive (t : R^o) 1 y (F (y t)).
+Definition is_sol (y : [the normedModType _ of R^o] -> U) :=
+  (forall t, t < 0 -> y t = 2 *: (y 0) - (y (- t)))%R /\
+  forall t, (0 <= t)%R -> is_derive (t : R^o) 1%R y (F (y t)).
 
 (* compact set used in LaSalle's invariance principle *)
 Variable K : set U.
@@ -199,106 +226,152 @@ Hypothesis Kco : compact K.
 (* solution function *)
 Variable (sol : U -> R -> U).
 Hypothesis (sol0 : forall p, sol p 0 = p).
-Hypothesis solP : forall y, K (y 0) -> is_sol y <-> y = sol (y 0).
+Hypothesis solP : forall y : R -> U, K (y 0%R) -> is_sol y <-> y = sol (y 0%R).
 Hypothesis sol_cont : forall t, continuous_on K (sol^~ t).
 
 Lemma sol_is_sol p : K p -> is_sol (sol p).
 Proof. by move=> Kp; apply/solP; rewrite sol0. Qed.
 Hint Resolve sol_is_sol.
 
-Lemma uniq_sol x y :
-  K (x 0) -> K (y 0) -> is_sol x -> is_sol y -> x 0 = y 0 -> x = y.
+Lemma uniq_sol (x y : R -> U) :
+  K (x 0%R) -> K (y 0%R) -> is_sol x -> is_sol y -> x 0%R = y 0%R -> x = y.
 Proof. by move=> Kx0 Ky0 /(solP Kx0)-> /(solP Ky0)->; rewrite !sol0 => ->. Qed.
 
-Definition is_invariant A := forall p, A p -> forall t, 0 <= t -> A (sol p t).
+Definition is_invariant A := forall p, A p -> forall t, (0 <= t)%R -> A (sol p t).
 
 Hypothesis Kinvar : is_invariant K.
 
 Definition shift_sol p t0 t :=
-  if t >= 0 then sol p (t + t0) else 2 *: (sol p t0) - (sol p (- t + t0)).
+  (if t >= 0 then sol p (t + t0) else 2 *: (sol p t0) - (sol p (- t + t0)))%R.
 
 (* to mathcomp/analysis *)
-Lemma nearN (R : absRingType) (P : set R) :
-  (\forall x \near (0 : R), P x) = (\forall x \near (0 : R), P (- x)).
+Lemma nearN (R : realFieldType) (P : set R) :
+  (\forall x \near (0%R : R^o), P x) = (\forall x \near (0%R : R^o), P (- x)%R).
 Proof.
-by rewrite propeqE; split=> /locallyP [e egt0 seP]; exists e => // x;
-  rewrite /AbsRing_ball /= sub0r -absrN -sub0r => /seP //; rewrite opprK.
+rewrite propeqE; split.
+  move/(@nbhs_ballP _ [the pseudoMetricType _ of R^o]).
+  move=> [e egt0 seP]; exists e => // x.
+  move=> ex.
+  apply: seP.
+  move: ex.
+  by rewrite /ball/= /ball_/= opprK !add0r normrN.
+move/(@nbhs_ballP _ [the pseudoMetricType _ of R^o]).
+move=> [e egt0 seP]; exists e => // x.
+move=> ex.
+rewrite -(opprK x).
+apply: seP.
+move: ex.
+by rewrite /ball/= /ball_/= opprK !add0r normrN.
 Qed.
 
-Lemma sol_shift p t0 : K p -> 0 <= t0 -> is_sol (shift_sol p t0).
+Lemma sol_shift p (t0 : R^o) : K p -> (0 <= t0)%R -> is_sol (shift_sol p t0).
 Proof.
 move=> Kp t0ge0; split=> [t tlt0|t tge0].
-  by rewrite /shift_sol lerNgt tlt0 lerr add0r ltrW ?oppr_gt0.
-suff dshift : (shift_sol p t0) \o shift t = cst (shift_sol p t0 t) +
-  (fun h => h *: F (shift_sol p t0 t)) +o_ (0 : R^o) id.
-  have dshiftE : 'd (shift_sol p t0) (t : R^o) =
-    (fun h => h *: F (shift_sol p t0 t)) :> (R^o -> U).
+  rewrite /shift_sol leNgt tlt0/= lexx/=.
+  rewrite ltW ?oppr_gt0//.
+  rewrite [X in _ = (2 *: sol p X - _)%R](_ : _ = t0)//.
+  set tmp := (0 + t0)%R.
+  by rewrite RplusE add0r.
+suff dshift : (shift_sol p t0) \o shift t = (cst (shift_sol p t0 t) +
+  (fun h : R^o => h *: F (shift_sol p t0 t)))%R +o_ (0%R : R^o) (id : R^o -> R^o).
+(*  have dshiftE : 'd (shift_sol p t0) (t : R^o) =
+    (fun h => h *: F (shift_sol p t0 t))%R :> (R^o -> U).
     have lin_scal : linear (fun h : R^o => h *: F (shift_sol p t0 t)).
       by move=> ???; rewrite scalerDl scalerA.
     have ->: (fun h : R^o => h *: F (shift_sol p t0 t)) = Linear lin_scal by [].
     apply: diff_unique; first exact: scalel_continuous.
-    by apply/eqaddoE; rewrite dshift.
+    by apply/eqaddoE; rewrite dshift.*)
+  move=> [:dshiftE].
   have diff_shift : differentiable (shift_sol p t0 : R^o -> _) t.
-    apply/diff_locallyP; split; last by apply/eqaddoE; rewrite dshift dshiftE.
-    by rewrite dshiftE; apply: scalel_continuous.
+    apply/diff_locallyP; split; last first.
+      apply/eqaddoE; rewrite dshift.
+      do 2 congr +%R.
+      abstract: dshiftE.
+      have lin_scal : linear (fun h : R^o => h *: F (shift_sol p t0 t))%R.
+        by move=> ???; rewrite scalerDl scalerA.
+      have ->: (fun h : R^o => h *: F (shift_sol p t0 t))%R = Linear lin_scal by [].
+      apply/esym.
+      apply: diff_unique; first exact: scalel_continuous.
+      by apply/eqaddoE; rewrite dshift.
+    by rewrite -dshiftE; apply: scalel_continuous.
   apply: DeriveDef; first exact/derivable1_diffP.
-  by rewrite deriveE // dshiftE scale1r.
+  by rewrite deriveE // -dshiftE scale1r.
 have /sol_is_sol [_ solp] := Kp.
-have /solp solp' : 0 <= t + t0 by apply: addr_ge0 => //; apply: ltrW.
+have /solp solp' : (0 <= t + t0)%R by apply: addr_ge0 => //; apply: ltrW.
 rewrite /shift_sol tge0.
-move: tge0; rewrite ler_eqVlt orbC => /orP [tgt0|/eqP teq0].
+move: tge0; rewrite le_eqVlt orbC => /orP [tgt0|/eqP teq0].
   apply/eqaddoP => _ /posnumP[e]; near=> s.
-  rewrite -![(_ + _ : _ -> _) _]/(_ + _) /=.
-  have /derivable_locally : derivable (sol p : R^o -> U) (t + t0) 1 by [].
-  rewrite funeqE => /(_ s) /=; rewrite addrA [_%:A]mulr1 =>->.
-  suff -> /= : 0 <= s + t.
-    rewrite derive_val addrC addrA [_ s + _]addrC subrr add0r; near: s.
-    by case: e => /=; apply/(eqoP (locally_filter_on (0 : R))).
-  near: s; exists t => // s; rewrite /AbsRing_ball /= absrB subr0 => ltst.
-  rewrite -ler_subl_addl sub0r; apply/ltrW; apply: ler_lt_trans ltst.
-  by rewrite absRE -normrN; apply: ler_norm.
-rewrite -teq0 add0r shift0; apply/eqaddoP => _ /posnumP[e]; near=> s.
-rewrite -![(_ + _ : _ -> _) _]/(_ + _) /= -[t0]add0r teq0.
-have /derivable_locally dsol : derivable (sol p : R^o -> U) (t + t0) 1 by [].
-have := dsol; rewrite funeqE => /(_ (- s)) /=; rewrite [_%:A]mulr1 =>->.
-have := dsol; rewrite funeqE => /(_ s) /=; rewrite [_%:A]mulr1 =>->.
+  rewrite -![(_ + _ : _ -> _)%R _]/(_ + _)%R /=.
+  have /derivable_nbhs : derivable (sol p : R^o -> U) (t + t0) 1 by [].
+  rewrite funeqE => /(_ s) /=; rewrite addrA [(_%:A)%R]mulr1 =>->.
+  suff -> /= : (0 <= s + t)%R.
+    rewrite derive_val addrC addrA [(_ s + _)%R]addrC subrr add0r; near: s.
+    by case: e => /=; apply/(eqoP (nbhs_filter_on (0%R : R))).
+  near: s; exists t => // s; rewrite /ball_ /= => ltst.
+  rewrite -ler_subl_addl sub0r; apply/ltW; apply: le_lt_trans ltst.
+  by rewrite sub0r ler_norm.
+rewrite -teq0.
+rewrite shift0.
+rewrite RplusE.
+rewrite add0r.
+apply/eqaddoP => _ /posnumP[e]; near=> s.
+rewrite -![(_ + _ : _ -> _)%R _]/(_ + _)%R /= -[t0]add0r teq0.
+have /derivable_nbhs dsol : derivable (sol p : R^o -> U) (t + t0) 1 by [].
+have := dsol; rewrite funeqE => /(_ (- s)%R) /=; rewrite [(_%:A)%R]mulr1 =>->.
+have := dsol; rewrite funeqE => /(_ s) /=; rewrite [(_%:A)%R]mulr1 =>->.
 rewrite -{1}teq0 derive_val; case: (lerP 0 s) => [le0s|lts0].
-  rewrite addrC addrA [_ s + _]addrC subrr add0r; near: s.
-  by case: e => /=; apply/(eqoP (locally_filter_on (0 : R))).
-rewrite !opprD oppox /cst /= addrACA -[(- _ : _ -> _) _]/(- _) !addrA.
-rewrite mulr2n scalerDl scale1r -[_ - _ - sol _ _]addrA -opprD subrr sub0r.
-rewrite scaleNr opprK addrC addKr -[in X in _ <= X]normmN; near: s.
-rewrite !near_simpl -(nearN (fun x : R^o => `|[_ x]| <= e%:num * `|[x]|)).
-by case: e => /=; apply/(eqoP (locally_filter_on (0 : R))).
+  rewrite addrC addrA [(_ s + _)%R]addrC subrr add0r; near: s.
+  by case: e => /=; apply/(eqoP (nbhs_filter_on (0%R : R))).
+rewrite !opprD oppox /cst /= addrACA -[(- _ : _ -> _)%R _]/(- _)%R !addrA.
+rewrite mulr2n scalerDl scale1r -[(_ - _ - sol _ _)%R]addrA -opprD subrr sub0r.
+rewrite scaleNr opprK addrC addKr -[in X in (_ <= X)%R]normrN; near: s.
+rewrite !near_simpl.
+rewrite -(nearN (fun x : R^o => `|_ x| <= e%:num * `|x|%R))%R.
+case: e => /= e e0.
+near=> x.
+set u := (X in `|X x|%R).
+near: x.
+have := (@eqoP _ _ _ _ (nbhs_filter_on (0%R : R^o)) id u).1.
+exact.
 Grab Existential Variables. all: end_near. Qed.
 
 Lemma solD p t0 t :
-  K p -> 0 <= t0 -> 0 <= t -> sol p (t + t0) = sol (sol p t0) t.
+  K p -> (0 <= t0)%R -> (0 <= t)%R -> sol p (t + t0) = sol (sol p t0) t.
 Proof.
 move=> Kp t0ge0 tge0; have /sol_shift /(_ t0ge0) /solP := Kp.
-rewrite [shift_sol _ _ _]/shift_sol lerr add0r => <-; last exact: Kinvar.
+rewrite [shift_sol _ _ _]/shift_sol lexx.
+rewrite RplusE.
+rewrite add0r.
+move=> <-; last exact: Kinvar.
 by rewrite /shift_sol tge0.
 Qed.
 
-Lemma invariant_plim p : K p -> is_invariant (cluster (sol p @ +oo)).
+Lemma invariant_plim p : K p -> is_invariant (cluster (sol p @ +oo%R)).
 Proof.
 move=> Kp q plim_q t0 t0_ge0 A B [M].
-wlog Mge0 : M / 0 <= M => [sufMge0|] solpMinfty_A.
-  apply: (sufMge0 (maxr 0 M)); first by rewrite ler_maxr lerr.
-  by move=> x; rewrite ltr_maxl => /andP [_]; apply: solpMinfty_A.
+wlog Mge0 : M / (0 <= M)%R => [sufMge0|] [Mreal solpMinfty_A].
+  apply: (sufMge0 (maxr 0%R M)); first by rewrite le_maxr lexx.
+  split.
+    by rewrite maxr_real.
+  by move=> x; rewrite lt_maxl => /andP[_]; apply: solpMinfty_A.
 have Kq : K q.
   apply: compact_closed => //.
-  by move=> C; apply: plim_q; exists 0 => t /ltrW tge0; apply: Kinvar.
+  move=> C qC.
+  move: plim_q; apply => //.
+  exists 0%R; split.
+    by rewrite realE lexx.
+  move=> t /ltW tge0.
+  by apply: Kinvar.
 move=> /(sol_cont Kq) /plim_q q_Bsolt0.
-have /q_Bsolt0 [_ [[[t tgtM <-] _]]] : (sol p @ +oo) (sol p @` (> M) `&` A).
-  by exists M => t tgtM; split; [apply: imageP|apply: solpMinfty_A].
-have tge0 : 0 <= t by apply/ltrW; apply: ler_lt_trans tgtM.
+have /q_Bsolt0 [_ [[[t tgtM <-] _]]] : (sol p @ +oo%R) (sol p @` (> M)%R `&` A).
+  by exists M; split => // => t tgtM; split; [apply: imageP|apply: solpMinfty_A].
+have tge0 : (0 <= t)%R by apply/ltW; apply: le_lt_trans tgtM.
 have Ksolpt : K (sol p t) by apply: Kinvar.
 move=> /(_ Ksolpt) /=; rewrite -solD // => Bsolpt0t; exists (sol p (t0 + t)).
 by split=> //; apply/solpMinfty_A/ltr_paddl.
 Qed.
 
-Definition limS (A : set U) := \bigcup_(q in A) cluster (sol q @ +oo).
+Definition limS (A : set U) := \bigcup_(q in A) cluster (sol q @ +oo%R).
 
 Lemma invariant_limS A : A `<=` K -> is_invariant (limS A).
 Proof.
@@ -307,75 +380,83 @@ by exists q => //; apply: invariant_plim => //; apply: sAK.
 Qed.
 
 Lemma nincr_lb_cvg (f : R -> R) :
-  (forall x y, 0 <= x <= y -> f y <= f x) ->
-  (exists M, f @` (>= 0) `<=` (> M)) -> cvg (f @ +oo).
+  (forall x y, 0 <= x <= y -> f y <= f x)%R ->
+  (exists M, f @` (>= 0)%R `<=` (> M)%R) -> cvg (f @ +oo%R).
 Proof.
 move=> fnincr [M ltMf].
-apply/cvg_ex; exists (inf (fun x => x \in f @` (>= 0))).
-move=> A /locallyP [_ /posnumP[e] infe_A].
-have imf_inf : has_inf (fun x => x \in f @` (>= 0)).
-  apply/has_infP; split; first by exists (f 0); rewrite in_setE; apply: imageP.
-  by exists M; apply/lbP => ?; rewrite in_setE => /ltMf /ltrW.
-have := imf_inf => /inf_adherent /(_ [gt0 of e%:num]) [x].
-rewrite in_setE => - [t tge0 <-] ltftinfe; exists t => s ltts; apply: infe_A.
-rewrite ball_absE /= absrB absRE ger0_norm.
+apply/cvg_ex; exists (inf (fun x => x \in f @` (>= 0)%R)).
+move=> A /nbhs_ballP [_ /posnumP[e] infe_A].
+have imf_inf : has_inf (fun x => x \in f @` (>= 0)%R).
+   split; first by exists (f 0%R); rewrite in_setE; apply: imageP.
+  by exists M; apply/lbP => ?; rewrite in_setE => /ltMf /ltW.
+have := imf_inf => /inf_adherent /(_ [gt0 of e%:num]%R) [x].
+rewrite in_setE => -[t tge0 <-] ltftinfe; exists t; split.
+  by rewrite realE tge0.
+move=> s ltts; apply: infe_A.
+rewrite /ball/=.
+rewrite distrC ger0_norm.
   rewrite ltr_subl_addl.
-  by apply: ler_lt_trans ltftinfe; apply: fnincr; rewrite tge0 (ltrW ltts).
+  by apply: le_lt_trans ltftinfe; apply: fnincr; rewrite tge0 (ltW ltts).
 rewrite subr_ge0 inf_lower_bound // in_setE; apply: imageP.
-by apply: ltrW; apply: ler_lt_trans ltts.
+by apply: ltW; apply: le_lt_trans ltts.
 Qed.
 
 (* todo: use directional derivative *)
 Lemma stable_limS (V : U -> R^o) :
   continuous_on K V ->
-  (forall p t, K p -> 0 <= t -> derivable (V \o sol p : R^o -> R^o) t 1) ->
-  (forall (p : U), K p -> derive1 (V \o sol p) 0 <= 0) ->
-  limS K `<=` [set p | derive1 (V \o sol p) 0 = 0].
+  (forall p t, K p -> (0 <= t)%R -> derivable (V \o sol p : R^o -> R^o) t 1) ->
+  (forall (p : U), K p -> derive1 (V \o sol p) 0 <= 0)%R ->
+  limS K `<=` [set p | derive1 (V \o sol p) 0 = 0]%R.
 Proof.
 move=> Vcont Vsol_drvbl Vsol'le0 p [q Kq plimp].
-have ssqRpK : sol q @` (>= 0) `<=` K by move=> _ [t tge0 <-]; apply: Kinvar.
+have ssqRpK : sol q @` (>= 0)%R `<=` K by move=> _ [t tge0 <-]; apply: Kinvar.
 (* should be inferred *)
-have atrF := at_right_proper_filter 0.
-suff : exists l, cluster (sol q @ +oo) `<=` V @^-1` [set l].
+have atrF := at_right_proper_filter 0%R.
+suff : exists l, cluster (sol q @ +oo%R) `<=` V @^-1` [set l].
   move=> [l Vpliml]; rewrite derive1E /derive cvg_at_rightE; last first.
     apply: Vsol_drvbl => //; apply: compact_closed => //.
     exact: sub_plim_clos_invar plimp.
-  apply: flim_map_lim => A A0; rewrite !near_simpl; near=> h.
-  rewrite /= sol0 addr0 [_%:A]mulr1 Vpliml.
-    by rewrite Vpliml // subrr scaler0; apply: locally_singleton.
-  by apply: invariant_plim => //; apply: ltrW; near: h; exists 1.
-suff cvVsol : cvg (V \o sol q @ +oo).
-  exists (lim (V \o sol q @ +oo)); apply: (c0_cvg_cst_on_plim Vcont)=> //.
+  apply: (@cvg_map_lim _ _ _ (at_right _)) => // A A0; rewrite !near_simpl; near=> h.
+  rewrite /= sol0 addr0 [(_%:A)%R]mulr1 Vpliml.
+    by rewrite Vpliml // subrr scaler0; apply: nbhs_singleton.
+  by apply: invariant_plim => //; apply: ltW; near: h; exists 1%R.
+suff cvVsol : cvg (V \o sol q @ +oo%R).
+  exists (lim (V \o sol q @ +oo%R)); apply: (c0_cvg_cst_on_plim Vcont)=> //.
   exact: compact_closed.
 apply: nincr_lb_cvg; last first.
   have: compact (V @` K) by apply: continuous_on_compact.
   move=> /compact_bounded [N imVltN].
-  exists (- (N + 1))=> _ [t tge0 <-].
-  suff : `|(V \o sol q) t| < N + 1 by rewrite ltr_norml => /andP [].
-  by apply: imVltN; [rewrite ltr_addl|apply/imageP/Kinvar].
+  exists (- (N + 2))%R=> _ [t tge0 <-].
+  suff : (`|(V \o sol q) t| < N + 2)%R.
+    by rewrite ltr_norml => /andP [].
+  rewrite (@le_lt_trans _ _ (N + 1)%R)// ?ltr_add2l ?ltr1n//.
+  by apply: imVltN.2; [rewrite ltr_addl|apply/imageP/Kinvar].
 move=> s t /andP [sge0 slet].
-apply: ler0_derive1_nincr (lerr _) slet (lerr _).
-  move=> r rst; apply: Vsol_drvbl => //; apply: ler_trans sge0 _.
+apply: ler0_derive1_nincr (lexx _) slet (lexx _).
+  move=> r rst; apply: Vsol_drvbl => //; apply: le_trans sge0 _.
   by rewrite (itvP rst).
-move=> r rst; have rge0 : 0 <= r by apply: ler_trans sge0 _; rewrite (itvP rst).
+move=> r rst; have rge0 : (0 <= r)%R by apply: le_trans sge0 _; rewrite (itvP rst).
 suff -> : derive1 (V \o sol q) r = derive1 (V \o (sol (sol q r))) 0.
   exact/Vsol'le0/Kinvar.
 rewrite derive1E /derive cvg_at_rightE; last exact: Vsol_drvbl.
 rewrite derive1E /derive cvg_at_rightE; last first.
   by apply: Vsol_drvbl => //; apply: Kinvar.
-congr (lim _); rewrite predeqE /= locally_filterE => A; split.
-  move=> [_/posnumP[e] Ae]; exists e%:num => // x xe xgt0.
-  by rewrite sol0 addr0 -solD //; [apply: Ae|rewrite [_%:A]mulr1 ltrW].
-move=> [_/posnumP[e] Ae]; exists e%:num => // x xe xgt0.
-by have /Ae - /(_ xe) := xgt0; rewrite sol0 addr0 -solD // [_%:A]mulr1 ltrW.
+congr (lim _); rewrite predeqE /= nbhs_filterE => A; split.
+  move=> [_/posnumP[e] Ae]; exists e%:num%R => // x xe xgt0.
+  by rewrite sol0 addr0 -solD //; [apply: Ae|rewrite [(_%:A)%R]mulr1 ltW].
+move=> [_/posnumP[e] Ae]; exists e%:num%R => // x xe xgt0.
+by have /Ae - /(_ xe) := xgt0; rewrite sol0 addr0 -solD // [(_%:A)%R]mulr1 ltW.
 Grab Existential Variables. all: end_near. Qed.
 
 Lemma cvg_to_limS (A : set U) : compact A -> is_invariant A ->
-  forall p, A p -> sol p @ +oo --> (limS A : set [uniformType of U]).
+  forall p, A p -> sol p @ +oo%R --> (limS A : set [pseudoMetricType _ of U]).
 Proof.
 move=> Aco Ainvar p Ap B [_/posnumP[e] limSeB].
-apply: (cvg_to_plim _ Aco); first by exists 0 => _/posnumP[?]; apply: Ainvar.
-by exists e%:num=> // q [r plimr re_q]; apply: limSeB; exists r => //; exists p.
+apply: (cvg_to_plim _ Aco).
+  exists 0%R; split => //.
+    by rewrite realE lexx.
+  by move=> _/posnumP[?]; apply: Ainvar.
+by exists e%:num%R=> // q [r plimr re_q]; apply: limSeB; exists r => //; exists p.
 Qed.
 
 End DifferentialSystem.

--- a/pendulum.v
+++ b/pendulum.v
@@ -20,16 +20,142 @@ Local Open Scope ring_scope.
 
 Notation "p ..[ i ]" := (p 0 (inZp i)) (at level 10).
 
-Lemma ge0_expr_ndecr (R : realDomainType) n (x y : R) :
-  0 <= x <= y -> x ^+ n <= y ^+ n.
+Lemma poly2_factor {R : realType} (a b c x : R) :
+  a != 0 -> a * (x ^+ 2) + b * x + c = 0 ->
+  x = (- b + Num.sqrt (b ^+ 2 - 4%:R * a * c)) / (2 * a) \/
+  x = (- b - Num.sqrt (b ^+ 2 - 4%:R * a * c)) / (2 * a).
 Proof.
-move=> /andP [xge0 yge0]; elim: n => [|n ihn]; first by rewrite !expr0.
-by rewrite !exprS ler_pM // exprn_ge0.
+move=> ane0 xroot.
+set dlt := b ^+ 2 - 4%:R * a * c.
+set x1 := (- b + Num.sqrt dlt) / (2 * a).
+set x2 := (- b - Num.sqrt dlt) / (2 * a).
+suff poly_fact : a * (x ^+ 2) + b * x + c = a * (x - x1) * (x - x2).
+  move: xroot; rewrite poly_fact => /eqP; rewrite mulf_eq0 => /orP [].
+    by rewrite mulrI_eq0; [rewrite subr_eq0 => /eqP->; left|apply/lregP].
+  by rewrite subr_eq0 => /eqP->; right.
+rewrite /x1 /x2; case: (lerP 0 dlt) => [dltge0|dltlt0].
+  rewrite -mulrA mulrBr mulrBl mulrBl opprB addrA [(x * x + _) + _]addrAC.
+  rewrite [_ / _ * x]mulrC.
+  rewrite -[in RHS](addrA (x * x + _)).
+  rewrite -(opprD (x * _)).
+  rewrite -mulrDr.
+  rewrite -mulrDl.
+  rewrite addrCA -[- b + _ - _]addrA subrr addr0 -mul2r.
+  rewrite invrM ?unitfE // [2 * _ * _]mulrC !mulrA mulfVK//.
+  rewrite addrAC mulrN opprK !mulrDr mulrA [a * (x / _ * _)]mulrCA !mulrA.
+  rewrite mulfVK// [b * _]mulrC; congr (_ + _ + _).
+  rewrite [a * _]mulrC -[_ * a * _]mulrA mulfV // mulr1.
+  rewrite ![_ * - _]mulrC !mulrA !mulrDr -!mulrDl !mulrN !mulNr !opprK.
+  rewrite [_ * Num.sqrt _]mulrC -addrA addKr -!expr2 sqr_sqrtr // /dlt.
+  rewrite opprD addrA subrr opprK add0r -mulrA -invrM ?unitfE //.
+  rewrite (_ : 4 = 2 * 2); last by rewrite -natrM.
+  rewrite mulrC !mulrA mulVf ?mul1r// (mulrC _ c) -mulrA divff ?mulr1//.
+  by rewrite mulf_eq0 negb_or ane0 pnatr_eq0.
+move: xroot; have -> : a * (x ^+ 2) + b * x + c =
+  a * ((x + b / (2 * a)) ^+ 2) + (c - b ^+ 2 / (4%:R * a)).
+  rewrite [in RHS]expr2 -mulrA mulrDr mulrDl [c - _]addrC addrA !mulrDr.
+  rewrite -[_ - _]addrA -[a * _ + _ + _ in RHS]addrA; congr (_ + _ + _).
+  rewrite addrA [(x + _) * _]mulrDl mulrDr addrA -mulrDr [x * _]mulrC -mulrDl.
+  rewrite -[LHS]addr0 -addrA; congr (_ + _).
+    rewrite mulrA; congr (_ * _); rewrite -mulrDl invrM ?unitfE //.
+    rewrite mulrC -mulrA [_ * a]mulrC mulVKr ?unitfE // mulrDl.
+    exact: splitr.
+  rewrite !mulrA [a * _]mulrC -[b * a / _]mulrA invrM ?unitfE //.
+  rewrite mulVKr ?unitfE // [b / _ * _]mulrAC -[_ / 2 * _]mulrA -mulrBr.
+  rewrite [_^-1 * _]mulrCA invrM ?unitfE // -mulrBr -invrM ?unitfE //.
+  by rewrite -natrM subrr !mulr0.
+suff : a * (x + b / (2 * a)) ^+ 2 + (c - b ^+ 2 / (4%:R * a)) != 0.
+  by move=> pn0 p0; move: pn0; rewrite p0 eq_refl.
+have := ane0; rewrite neq_lt => /orP [alt0|agt0]; last first.
+  apply:lt0r_neq0; rewrite ltr_wpDl //; first by rewrite pmulr_rge0 // sqr_ge0.
+  rewrite subr_gt0 ltr_pdivrMr; last by rewrite pmulr_rgt0.
+  by rewrite mulrC -subr_lt0.
+rewrite -oppr_eq0 opprD; apply: lt0r_neq0; rewrite ltr_wpDl //.
+  by rewrite oppr_ge0 nmulr_rle0 // sqr_ge0.
+rewrite oppr_gt0 subr_lt0 ltr_ndivlMr; last by rewrite mulrC nmulr_rlt0.
+by rewrite mulrC -subr_lt0.
 Qed.
+
+Lemma deriveE' {R : realType} (V W : normedModType R) (f : V -> W) x v :
+  derive f x v = derive (fun h : R^o => f (h *: v + x)) 0 1.
+Proof.
+rewrite /derive.
+set g1 := fun h => h^-1 *: _; set g2 := fun h => h^-1 *: _.
+suff -> : g1 = g2 by [].
+by rewrite funeqE /g1 /g2 => h /=; rewrite addr0 scale0r add0r [_%:A]mulr1.
+Qed.
+
+Lemma bounded_poly {R : realType} (a b c d : R) :
+  0 < a -> \forall M \near +oo, forall x,
+  a * (x ^+ 2) - (b * `|x|) - c < d -> `|x| < M.
+Proof.
+move=> agt0.
+suff ptoinfty : (fun x => a * (x ^+ 2) - (b * `|x|) - c) @ +oo --> +oo.
+  have dleatinfty : +oo (>= d).
+    exists d; split => //.
+      by rewrite num_real.
+    by move=> // ? /ltW.
+  have /ptoinfty [M1 [M1real sgtM1pged]] := dleatinfty; near=> M.
+  move=> x pxltd; rewrite ltNge; apply/negP => Mlex.
+  move: pxltd; rewrite ltNge => /negP; apply.
+  rewrite -(@ger0_norm _ `|x|) // -(@ger0_norm _ (_ ^+ 2)) ?sqr_ge0 // normrX.
+  by apply: sgtM1pged; apply: lt_le_trans Mlex; near: M; exists M1.
+move=> A [M [Mreal sgtMA]]; rewrite !near_simpl; near=> x.
+have lt0x : 0 < x by [].
+rewrite ger0_norm ?ltW //; apply: sgtMA.
+rewrite ltrBrDr expr2 mulrA -mulrBl; apply: le_lt_trans (ler_norm _) _.
+rewrite -[ `|_|%R]sqr_sqrtr // expr2; apply: ltr_pM; last 1 first.
+- by near: x; exists (Num.sqrt `|M + c|); split => //.
+- exact: sqrtr_ge0.
+- exact: sqrtr_ge0.
+rewrite ltrBrDr -ltr_pdivrMl //; near: x.
+exists (a^-1 * (Num.sqrt `|M + c| + b)); split => //.
+rewrite realM//.
+  by rewrite realV// num_real.
+by rewrite realD// num_real.
+Unshelve. all: by end_near. Qed.
+
+(* TODO: generalize *)
+Lemma eq0_derive1_cst {R : realType} (f : R^o -> R^o) (a b : R) :
+  (forall t, t \in `[a, b] -> is_derive (t : R^o) 1 f 0) ->
+  forall t, t \in `[a, b] -> f t = f a.
+Proof.
+move=> f'eq0 t tab; apply/eqP; rewrite eq_le; apply/andP; split.
+  apply: (@ler0_derive1_le_cc _ _ a b) => //; rewrite ?(itvP tab) //;[
+    by move=> x /subset_itv_oo_cc /f'eq0 // df; rewrite derive1E derive_val..|].
+  apply: continuous_in_subspaceT => x.
+  rewrite inE/= => /f'eq0.
+  move=> /(@ex_derive _ [the normedModType R of R^o]).
+  move=> /derivable1_diffP /differentiable_continuous.
+  exact.
+apply: (@ger0_derive1_ndecr _ _ a b) => //; rewrite ?(itvP tab) //;[
+  by move=> x /subset_itv_oo_cc /f'eq0 // df; rewrite derive1E derive_val..|].
+apply: continuous_in_subspaceT => x.
+rewrite inE/= => /f'eq0.
+move=> /(@ex_derive _ [the normedModType R of R^o]).
+move=> /derivable1_diffP /differentiable_continuous.
+exact.
+Qed.
+
+Lemma is_derive_nneg_eq {R : realType} (f h : R^o -> R^o) (t : R^o) l1 l2 :
+  (forall t, 0 <= t -> f t = h t) -> 0 <= t ->
+  is_derive t 1 f l1 -> is_derive t 1 h l2 -> l1 = l2.
+Proof.
+move=> feg tge0 df dh.
+have /@derive_val <- := df; have /@derive_val <- := dh.
+apply: subr0_eq; rewrite -deriveB // /derive cvg_at_rightE; last first.
+  by rewrite -[cvg _]/(derivable _ _ _).
+apply: cvg_lim => A A0.
+  by rewrite -closeEnbhs norm_closeE.
+rewrite !near_simpl; near=> r.
+rewrite /= -![(_ - _ : _ -> _) _]/(_ - _) !feg //.
+  by rewrite !subrr scaler0; apply: nbhs_singleton.
+by rewrite addr_ge0 // [_%:A]mulr1 ltW //; near: h; exists 1.
+Unshelve. all: by end_near. Qed.
 
 Section System.
 Context {R : realType}.
-Parameter m M l g : {posnum R}.
+Variable m M l g : {posnum R}.
 
 Variable ke kv kx kd : {posnum R}.
 
@@ -85,15 +211,6 @@ have -> : (fun q => (f q)..[i]) = (fun v => v..[i]) \o f by rewrite funeqE.
 (* This should work *)
 (* apply: is_diff_eq. *)
 exact: is_diff_comp.
-Qed.
-
-Lemma deriveE' (V W : normedModType R) (f : V -> W) x v :
-  derive f x v = derive (fun h : R^o => f (h *: v + x)) 0 1.
-Proof.
-rewrite /derive.
-set g1 := fun h => h^-1 *: _; set g2 := fun h => h^-1 *: _.
-suff -> : g1 = g2 by [].
-by rewrite funeqE /g1 /g2 => h /=; rewrite addr0 scale0r add0r [_%:A]mulr1.
 Qed.
 
 Global Instance is_derive_component (V : normedModType R) n
@@ -162,69 +279,34 @@ Qed.
 Lemma K_closed : closed K.
 Proof. exact: closedI circle_closed preimV_lek0_closed. Qed.
 
-Lemma bounded_poly (a b c d : R) :
-  0 < a -> \forall M \near +oo, forall x,
-  a * (x ^+ 2) - (b * `|x|) - c < d -> `|x| < M.
-Proof.
-move=> agt0.
-suff ptoinfty : (fun x => a * (x ^+ 2) - (b * `|x|) - c) @ +oo --> +oo.
-  have dleatinfty : +oo (>= d).
-    exists d; split => //.
-      by rewrite realE; exact: le_total.
-    by move=> // ? /ltW.
-  have /ptoinfty [M1 [M1real sgtM1pged]] := dleatinfty; near=> M.
-  move=> x pxltd; rewrite ltNge; apply/negP => Mlex.
-  move: pxltd; rewrite ltNge => /negP; apply.
-  rewrite -(@ger0_norm _ `|x|) // -(@ger0_norm _ (_ ^+ 2)) ?sqr_ge0 // normrX.
-  by apply: sgtM1pged; apply: lt_le_trans Mlex; near: M; exists M1.
-move=> A [M [Mreal sgtMA]]; rewrite !near_simpl; near=> x.
-have lt0x : 0 < x.
-  near: x.
-  by exists 0; split => //.
-rewrite ger0_norm ?ltW //; apply: sgtMA.
-rewrite ltrBrDr expr2 mulrA -mulrBl; apply: le_lt_trans (ler_norm _) _.
-rewrite -[ `|_|%R]sqr_sqrtr // expr2; apply: ltr_pM; last 1 first.
-- by near: x; exists (Num.sqrt `|M + c|); split => //.
-- exact: sqrtr_ge0.
-- exact: sqrtr_ge0.
-rewrite ltrBrDr -ltr_pdivrMl //; near: x.
-exists (a^-1 * (Num.sqrt `|M + c| + b)); split => //.
-rewrite realM//.
-  by rewrite realV// realE (ltW agt0).
-rewrite realD//.
-by rewrite realE; apply: le_total.
-Unshelve. all: by end_near. Qed.
-
 Lemma K_bounded : bounded_set K.
 Proof.
 suff : \forall M \near +oo, forall p, K p -> forall i, `|p ord0 i| < M.
-  rewrite /bounded_set; apply: filter_app; near=> M.
-  move=> Kbnd /= p /Kbnd ltpM.
+  rewrite /bounded_set; apply: filter_app; near=> M0.
+  move=> Kbnd /= p /Kbnd ltpM0.
   rewrite /normr/=.
   rewrite mx_normrE.
-  apply/bigmax_leP; split => //.
-  move=> i _.
+  apply/bigmax_leP; split => //= i _.
   rewrite ord1.
-  apply/ltW.
-  by apply: ltpM.
+  exact/ltW/ltpM0.
 suff : \forall M \near +oo, forall p, K p -> `| p..[0] | < M /\
   `| p..[1] | < M /\ `| p..[2] | < M /\ `| p..[3] | < M /\ `| p..[4] | < M.
-  apply: filter_app; near=> M.
+  apply: filter_app; near=> M0.
   move=> Kbnd p /Kbnd [ltp0M [ltp1M [ltp2M [ltp3M ltp4M]]]].
   case; do 5 ?[case; first by move=> ?; rewrite -[ Ordinal _ ]natr_Zp Zp_nat].
   by move=> n ?; suff : (n.+1.+4 < 5)%N by rewrite !ltnS ltn0.
 have K1bnd : \forall M \near +oo, forall p, K p -> `| p..[1] | < M.
-  near=> M => p [_ Vps].
+  near=> M0 => p [_ Vps].
     suff /lt_trans : `| p..[1] | < Num.sqrt (2 * B / kv%:num).
-    by apply; near: M; exists (Num.sqrt (2 * B / kv%:num)); split => //.
+    by apply; near: M0; exists (Num.sqrt (2 * B / kv%:num)); split => //.
   rewrite -sqrtr_sqr ltr_sqrt // mulrAC -ltr_pdivrMl // invf_div; last first.
     by rewrite mulr0 /B/=.
   apply: le_lt_trans k0_valid; apply: le_trans Vps.
   by rewrite [V _]addrAC lerDr addr_ge0 // pmulr_rge0 // sqr_ge0.
-apply: filter_app (K1bnd); near=> M.
+apply: filter_app (K1bnd); near=> M0.
 move=> K1ltM p Kp; have [circp Vps] := Kp; split.
   suff /lt_trans : `| p..[0] | < Num.sqrt (2 * B / kx%:num).
-    by apply; near: M; exists (Num.sqrt (2 * B / kx%:num)); split => //.
+    by apply; near: M0; exists (Num.sqrt (2 * B / kx%:num)); split => //.
   rewrite -sqrtr_sqr ltr_sqrt // mulrAC -ltr_pdivrMl // invf_div; last first.
     by rewrite mulr0 /B.
   apply: le_lt_trans k0_valid; apply: le_trans Vps.
@@ -232,20 +314,20 @@ move=> K1ltM p Kp; have [circp Vps] := Kp; split.
 split; first exact: K1ltM; split.
   suff /le_lt_trans : `| p..[2] | <= 1.
     apply.
-    by near: M; exists 1; split => //.
+    by near: M0; exists 1.
   by rewrite -sqrtr_sqr -sqrtr1 ler_sqrt // -circp lerDl sqr_ge0.
 split.
   suff /le_lt_trans : `| p..[3] | <= 1.
     apply.
-    by near: M; exists 1; split => //.
+    by near: M0; exists 1.
   by rewrite -sqrtr_sqr -sqrtr1 ler_sqrt // -circp lerDr sqr_ge0.
-move: p Kp {circp Vps}; near: M; rewrite /= !near_simpl.
+move: p Kp {circp Vps}; near: M0; rewrite /= !near_simpl.
 have [M1 [M1real sgtM1gtK1]] := K1bnd.
 have := bounded_poly (m%:num * l%:num * ((`|M1| + 1) ^+ 2))
   (m%:num * l%:num * g%:num * ((`|M1| + 1) + 1)) (Num.sqrt (2 * B / ke%:num))
   [gt0 of m%:num * (l%:num ^+ 2) / 2].
-apply: filter_app; near=> M => sEsltM p Kp; have [circp Vps] := Kp.
-apply: sEsltM.
+apply: filter_app; near=> M0 => sEsltM0 p Kp; have [circp Vps] := Kp.
+apply: sEsltM0.
 have : E p < Num.sqrt (2 * B / ke%:num).
   apply: le_lt_trans (ler_norm _) _.
   rewrite -sqrtr_sqr ltr_sqrt // mulrAC -ltr_pdivrMl // invf_div; last first.
@@ -288,9 +370,8 @@ suff : 2 * (V p) / ke%:num < (kv%:num / (ke%:num * (M%:num + m%:num))) ^+ 2.
   by rewrite /V -addrA lerDl addr_ge0 // pmulr_rge0 // sqr_ge0.
 rewrite ltr_pdivrMr // mulrC -ltr_pdivlMr // (lt_le_trans Vp_s) //.
 rewrite -mulrA mulrCA mulrA; apply: ler_pM => //; apply: ler_pM => //.
-apply/ge0_expr_ndecr/andP; split; last first.
-  by rewrite ge_min/= lexx.
-by rewrite le_min; apply/andP; split.
+rewrite lerXn2r// ?nnegrE//.
+by rewrite ge_min/= lexx.
 Qed.
 
 Lemma fctrl_wdef (p : U) : (p..[2] ^+ 2) + (p..[3] ^+ 2) = 1 -> V p < B ->
@@ -313,32 +394,10 @@ Qed.
 
 (* TODO: show that Fpendulum is smooth in K and remove these hypotheses using
   Cauchy-Lipschitz *)
-Variable (sol : U -> R -> U).
+Variable sol : U -> R -> U.
 Hypothesis (sol0 : forall p, sol p 0 = p).
 Hypothesis solP : forall y, K (y 0) -> is_sol Fpendulum y <-> y = sol (y 0).
 Hypothesis sol_cont : forall t, continuous_on K (sol^~ t).
-
-(* TODO: generalize *)
-Lemma eq0_derive1_cst (f : R^o -> R^o) (a b : R) :
-  (forall t, t \in `[a, b] -> is_derive (t : R^o) 1 f 0) ->
-  forall t, t \in `[a, b] -> f t = f a.
-Proof.
-move=> f'eq0 t tab; apply/eqP; rewrite eq_le; apply/andP; split.
-  apply: (@ler0_derive1_le_cc _ _ a b) => //; rewrite ?(itvP tab) //;[
-    by move=> x /subset_itv_oo_cc /f'eq0 // df; rewrite derive1E derive_val..|].
-  apply: continuous_in_subspaceT => x.
-  rewrite inE/= => /f'eq0.
-  move=> /(@ex_derive _ [the normedModType R of R^o]).
-  move=> /derivable1_diffP /differentiable_continuous.
-  exact.
-apply: (@ger0_derive1_ndecr _ _ a b) => //; rewrite ?(itvP tab) //;[
-  by move=> x /subset_itv_oo_cc /f'eq0 // df; rewrite derive1E derive_val..|].
-apply: continuous_in_subspaceT => x.
-rewrite inE/= => /f'eq0.
-move=> /(@ex_derive _ [the normedModType R of R^o]).
-move=> /derivable1_diffP /differentiable_continuous.
-exact.
-Qed.
 
 Lemma circ_invar p :
   K p -> forall t, 0 <= t -> (sol p t)..[2] ^+ 2 + (sol p t)..[3] ^+ 2 = 1.
@@ -346,7 +405,7 @@ Proof.
 move=> Kp /= t tge0; have [circp _] := Kp; rewrite -circp -[in RHS](sol0 p).
 pose f s := (sol p s)..[2] ^+ 2 + (sol p s)..[3] ^+ 2; rewrite -!/(f _).
 (* BUG in unification *)
-apply (@eq0_derive1_cst (f : R^o -> R^o) 0 t); last first.
+apply (@eq0_derive1_cst R (f : R^o -> R^o) 0 t); last first.
   by rewrite in_itv/= lexx tge0.
 move=> s s0t; have sge0 : s >= 0 by rewrite (itvP s0t).
 have [_ /(_ _ sge0) dsol] := sol_is_sol sol0 solP Kp.
@@ -390,9 +449,8 @@ rewrite [(_ + _) * _]mulrDr addrAC [_ + _ * y + _]addrAC.
 apply: (canLR (subrK _)); rewrite -mulrBl [_ * (_ + y)]mulrDr opprD addrA.
 rewrite [_ * (_ - _ * y)]mulrDr addrA -[- (_ * y)]mulNr [_ * (_ * y)]mulrA.
 rewrite [_ + _ * y + _]addrAC; apply: (canLR (subrK _)); rewrite -mulrBl.
-rewrite [in RHS]mulrN opprK mulrACA [_ ^+2 / _]mulrAC mulfVK //.
-rewrite [_ / _]mulrC ![_^-1 * _]mulrA [_^-1 * _ * _]mulrC mulVKf //.
-rewrite /=.
+rewrite [in RHS]mulrN opprK mulrACA [_ ^+2 / _]mulrAC mulfVK//.
+rewrite [_ / _]mulrC ![_^-1 * _]mulrA [_^-1 * _ * _]mulrC mulVKf//.
 ring.
 Qed.
 
@@ -416,8 +474,8 @@ rewrite -[_ * fctrl _](mulfVK Mpmsne0) [_ / _ * _]mulrAC -mulrDl.
 apply: (canLR (mulfK _)) => //; rewrite [kv%:num * _]mulrDr addrA addrAC.
 apply: (canLR (subrK _)); rewrite mulrAC -mulrDl /fctrl [LHS]mulrA.
 have circp : (sol p t)..[2] ^+ 2 + (sol p t)..[3] ^+ 2 = 1 by apply: circ_invar.
-have fctrl_def := fctrl_wdef circp Vsolpt_s; apply: (canLR (mulfK _)) => //.
-rewrite /=; ring.
+have ? := fctrl_wdef circp Vsolpt_s; apply: (canLR (mulfK _)) => //.
+ring.
 Qed.
 
 Lemma defset_invar p : K p -> forall t, 0 <= t ->
@@ -549,8 +607,8 @@ move=> p [q Kq solq_top].
 apply: compact_closed (@norm_hausdorff _ _) K_compact _ _.
 have solqK : (sol q @ +oo) K.
   exists 0; split.
-    by rewrite realE lexx.
-  by move=> ? /ltW; apply: Kinvar.
+    by rewrite real0.
+  by move=> ? /ltW; exact: Kinvar.
 by move=> A /solq_top - /(_ _ solqK) [r []]; exists r.
 Qed.
 
@@ -582,23 +640,6 @@ rewrite derive1E derive_val mulrI_eq0; last exact/lregN/lregP.
 by rewrite sqrf_eq0 => /eqP.
 Qed.
 
-Lemma is_derive_nneg_eq (f g : R^o -> R^o) (t : R^o) l1 l2 :
-  (forall t, 0 <= t -> f t = g t) -> 0 <= t ->
-  is_derive t 1 f l1 -> is_derive t 1 g l2 -> l1 = l2.
-Proof.
-move=> feg tge0 df dg.
-have /@derive_val <- := df; have /@derive_val <- := dg.
-apply: subr0_eq; rewrite -deriveB // /derive cvg_at_rightE; last first.
-  by rewrite -[cvg _]/(derivable _ _ _).
-apply: cvg_lim => A A0.
-  rewrite -closeEnbhs.
-  by rewrite norm_closeE.
-rewrite !near_simpl; near=> h.
-rewrite /= -![(_ - _ : _ -> _) _]/(_ - _) !feg //.
-  by rewrite !subrr scaler0; apply: nbhs_singleton.
-by rewrite addr_ge0 // [_%:A]mulr1 ltW //; near: h; exists 1 => //=.
-Unshelve. all: by end_near. Qed.
-
 Lemma sol1'_eq0 p t : limS sol K p -> 0 <= t -> (Fpendulum (sol p t))..[1] = 0.
 Proof.
 move=> limSKp tge0; have := is_derive_cst (0 : R^o) (t : R^o) 1.
@@ -610,7 +651,7 @@ Qed.
 Lemma sol0_const p t : limS sol K p -> 0 <= t -> (sol p t)..[0] = p..[0].
 Proof.
 move=> limSKp tge0; rewrite -[p in RHS]sol0.
-apply (@eq0_derive1_cst (fun s => (sol p s)..[0]) 0 t); last first.
+apply (@eq0_derive1_cst R (fun s => (sol p s)..[0]) 0 t); last first.
   by rewrite in_itv/= lexx tge0.
 move=> s /andP [sge0 _]; have /subset_limSK_K Kp := limSKp.
 have [_ /(_ _ sge0) /(is_derive_component 0) dsol0] := sol_is_sol sol0 solP Kp.
@@ -620,7 +661,7 @@ Qed.
 Lemma Esol_const p t : limS sol K p -> 0 <= t -> (E \o sol p) t = E p.
 Proof.
 move=> limSKp tge0; rewrite -[p in RHS]sol0.
-apply (@eq0_derive1_cst (E \o sol p) 0 t); last first.
+apply (@eq0_derive1_cst R (E \o sol p) 0 t); last first.
   by rewrite in_itv/= lexx tge0.
 move=> s /andP [sge0 _]; have /subset_limSK_K Kp := limSKp.
 have dEsol := is_derive_Esol Kp sge0; apply: DeriveDef => //.
@@ -645,7 +686,7 @@ rewrite opprD [RHS]mulrDl [RHS]addrC; apply/(canRL (subrK _))/Logic.eq_sym.
 rewrite mulrC -mulNr mulrA mulrA; apply: (canLR (mulfK _)) => //.
 rewrite [RHS]mulrDr [LHS]mulrDr addrC; apply: (canLR (subrK _)).
 rewrite mulrA -[in X in X / _]mulrA; apply: (canLR (mulfK _)) => //.
-rewrite /=; ring.
+ring.
 Qed.
 
 Lemma div_fctrl_mP p t : limS sol K p -> 0 <= t ->
@@ -664,12 +705,12 @@ Lemma Fpendulum4E p t : limS sol K p -> 0 <= t ->
 Proof.
 move=> limSKp tge0; rewrite !mxE /=.
 have /(canLR (mulfVK _)) <- // := div_fctrl_mP limSKp tge0.
-apply: (canLR (mulfK _)); last apply/Logic.eq_sym.
+apply: (canLR (mulfK _)); last apply/esym.
   by apply: lt0r_neq0; rewrite pmulr_rgt0 // Mp_ms_gt0.
-rewrite mulrCA mulrA mulrA [l%:num * _ in LHS]mulrC mulrVK ?unitfE //.
+rewrite mulrCA mulrA mulrA [l%:num * _ in LHS]mulrC mulfVK//.
 have [] : K (sol p t) by apply/subset_limSK_K/limSKinvar.
 rewrite addrC => /(canRL (addrK _)) -> _.
-rewrite /=; ring.
+ring.
 Qed.
 
 Lemma En0_fctrlsol_const p t :
@@ -690,29 +731,29 @@ Proof.
 move=> infA; have [[t At] _] := infA.
 have Amin : \big[minr/t]_(s <- enum_fset A) s \in A.
   have : forall s, s \in enum_fset A -> s \in A by [].
-  elim: (enum_fset A) => [inA|s l ihl inA]; first by rewrite big_nil.
+  elim: (enum_fset A) => [inA|s l0 ihl0 inA]; first by rewrite big_nil.
   rewrite big_cons.
   have [sl|sl] := leP s _.
     by apply: inA; rewrite mem_head.
-  by apply: ihl => r lr; apply: inA; rewrite inE orbC lr.
+  by apply: ihl0 => r lr; apply: inA; rewrite inE orbC lr.
 suff -> : inf [set t | t \in A] = \big[minr/t]_(s <- enum_fset A) s by [].
 apply/eqP; rewrite eq_le; apply/andP; split.
   apply: inf_lbound => //.
   by case: infA.
 apply: lb_le_inf; first by have [] := infA.
 apply/lbP => s As; have : s \in enum_fset A by [].
-elim: (enum_fset A) => // r l ihl; rewrite inE => /orP [/eqP <-|].
+elim: (enum_fset A) => // r l0 ihl0; rewrite inE => /orP [/eqP <-|].
   by rewrite big_cons ge_min lexx.
-by rewrite big_cons ge_min orbC => /ihl ->.
+by rewrite big_cons ge_min orbC => /ihl0 ->.
 Qed.
 
-Lemma continuous_finimage_cst (f : R -> R) n (g : 'I_n -> R) :
+Lemma continuous_finimage_cst (f : R -> R) n (h : 'I_n -> R) :
   {in (>= 0), continuous f} ->
-  (forall t, 0 <= t -> exists i, f t = g i) ->
+  (forall t, 0 <= t -> exists i, f t = h i) ->
   forall t, 0 <= t -> f t = f 0.
 Proof.
-case: n g => [g ? finim_f t tge0|]; first by have /finim_f [] := tge0; case.
-case=> [|n] g fcont finim_f t tge0.
+case: n h => [h ? finim_f t tge0|]; first by have /finim_f [] := tge0; case.
+case=> [|n] h fcont finim_f t tge0.
   have /finim_f [i ->] := tge0; have /finim_f [j ->] := lexx (0 : R).
   by rewrite !ord1.
 case: (eqVneq (f t) (f 0)) => // ftnef0.
@@ -723,8 +764,8 @@ have ltflr : fl < fr.
     rewrite /fl; move: (left0) => /min_idPl => ->.
     by rewrite lt_def ftnef0/= left0.
   by rewrite /fl; move/ltW: (lt0ft) => /min_idPr => ->.
-set img := [set x | (fl < x) && (x \in g @` setT)].
-have imgfr : (g @` setT) fr.
+set img := [set x | (fl < x) && (x \in range h)].
+have imgfr : (range h) fr.
   rewrite /fr.
   have [f0ft|f0ft] := leP (f 0) (f t).
     by have /finim_f [i] := tge0; exists i.
@@ -755,7 +796,7 @@ move=> s s0t fsemid; suff ltfl_inf : fl < inf img.
     by rewrite ltr_pdivlMr // mulrC mul2r ltrD2l.
   by rewrite ler_pdivlMr // mulrC mul2r lerD2r leNgt ltfl_inf.
 have imgE : img = pred_of_finset [fset x in
-  [seq t <- [seq g i | i : 'I_n.+2] | fl < t]]%fset :> set R.
+  [seq t <- [seq h i | i : 'I_n.+2] | fl < t]]%fset :> set R.
   rewrite funeqE => x; rewrite /img /= /pred_of_finset in_fset/=.
   apply/propext; split.
     rewrite mem_filter => /andP[flx].
@@ -770,62 +811,6 @@ rewrite imgE; set A := [fset x in _]%fset.
 have : inf (pred_of_finset A) \in A.
   by apply: inf_in_finset; rewrite -[X in has_inf X]imgE.
 by rewrite /A in_fset mem_filter => /andP [].
-Qed.
-
-Lemma poly2_factor (a b c x : R) :
-  a != 0 -> a * (x ^+ 2) + b * x + c = 0 ->
-  x = (- b + Num.sqrt (b ^+ 2 - 4%:R * a * c)) / (2 * a) \/
-  x = (- b - Num.sqrt (b ^+ 2 - 4%:R * a * c)) / (2 * a).
-Proof.
-move=> ane0 xroot.
-set dlt := b ^+ 2 - 4%:R * a * c.
-set x1 := (- b + Num.sqrt dlt) / (2 * a).
-set x2 := (- b - Num.sqrt dlt) / (2 * a).
-suff poly_fact : a * (x ^+ 2) + b * x + c = a * (x - x1) * (x - x2).
-  move: xroot; rewrite poly_fact => /eqP; rewrite mulf_eq0 => /orP [].
-    by rewrite mulrI_eq0; [rewrite subr_eq0 => /eqP->; left|apply/lregP].
-  by rewrite subr_eq0 => /eqP->; right.
-rewrite /x1 /x2; case: (lerP 0 dlt) => [dltge0|dltlt0].
-  rewrite -mulrA mulrBr mulrBl mulrBl opprB addrA [(x * x + _) + _]addrAC.
-  rewrite [_ / _ * x]mulrC.
-  rewrite -[in RHS](addrA (x * x + _)).
-  rewrite -(opprD (x * _)).
-  rewrite -mulrDr.
-  rewrite -mulrDl.
-  rewrite addrCA -[- b + _ - _]addrA subrr addr0 -mul2r.
-  rewrite invrM ?unitfE // [2 * _ * _]mulrC !mulrA mulrVK ?unitfE //.
-  rewrite addrAC mulrN opprK !mulrDr mulrA [a * (x / _ * _)]mulrCA !mulrA.
-  rewrite mulrVK ?unitfE // [b * _]mulrC; congr (_ + _ + _).
-  rewrite [a * _]mulrC -[_ * a * _]mulrA mulfV // mulr1.
-  rewrite ![_ * - _]mulrC !mulrA !mulrDr -!mulrDl !mulrN !mulNr !opprK.
-  rewrite [_ * Num.sqrt _]mulrC -addrA addKr -!expr2 sqr_sqrtr // /dlt.
-  rewrite opprD addrA subrr opprK add0r -mulrA -invrM ?unitfE //.
-  rewrite (_ : 4 = 2 * 2); last by rewrite -natrM.
-  rewrite mulrC !mulrA mulVf ?mul1r// (mulrC _ c) -mulrA divff ?mulr1//.
-  by rewrite mulf_eq0 negb_or ane0 pnatr_eq0.
-move: xroot; have -> : a * (x ^+ 2) + b * x + c =
-  a * ((x + b / (2 * a)) ^+ 2) + (c - b ^+ 2 / (4%:R * a)).
-  rewrite [in RHS]expr2 -mulrA mulrDr mulrDl [c - _]addrC addrA !mulrDr.
-  rewrite -[_ - _]addrA -[a * _ + _ + _ in RHS]addrA; congr (_ + _ + _).
-  rewrite addrA [(x + _) * _]mulrDl mulrDr addrA -mulrDr [x * _]mulrC -mulrDl.
-  rewrite -[LHS]addr0 -addrA; congr (_ + _).
-    rewrite mulrA; congr (_ * _); rewrite -mulrDl invrM ?unitfE //.
-    rewrite mulrC -mulrA [_ * a]mulrC mulVKr ?unitfE // mulrDl.
-    exact: splitr.
-  rewrite !mulrA [a * _]mulrC -[b * a / _]mulrA invrM ?unitfE //.
-  rewrite mulVKr ?unitfE // [b / _ * _]mulrAC -[_ / 2 * _]mulrA -mulrBr.
-  rewrite [_^-1 * _]mulrCA invrM ?unitfE // -mulrBr -invrM ?unitfE //.
-  by rewrite -natrM subrr !mulr0.
-suff : a * (x + b / (2 * a)) ^+ 2 + (c - b ^+ 2 / (4%:R * a)) != 0.
-  by move=> pn0 p0; move: pn0; rewrite p0 eq_refl.
-have := ane0; rewrite neq_lt => /orP [alt0|agt0]; last first.
-  apply:lt0r_neq0; rewrite ltr_wpDl //; first by rewrite pmulr_rge0 // sqr_ge0.
-  rewrite subr_gt0 ltr_pdivrMr; last by rewrite pmulr_rgt0.
-  by rewrite mulrC -subr_lt0.
-rewrite -oppr_eq0 opprD; apply: lt0r_neq0; rewrite ltr_wpDl //.
-  by rewrite oppr_ge0 nmulr_rle0 // sqr_ge0.
-rewrite oppr_gt0 subr_lt0 ltr_ndivlMr; last by rewrite mulrC nmulr_rlt0.
-by rewrite mulrC -subr_lt0.
 Qed.
 
 Lemma En0_sol2_const p :
@@ -867,7 +852,7 @@ have sol432_val' s : 0 <= s ->
   rewrite -![_ *: _]/(_ * _) mulrA mulrAC mulrA; apply: (canLR (mulfK _)) => //.
   rewrite [in RHS]mulrDl; apply: (canRL (subrK _)).
   rewrite [(sol p s)..[3] * _]mulrDr [in RHS]mulrDl; apply: (canRL (subrK _)).
-  rewrite [_ / _ * _]mulrC [in RHS]mulrA [in RHS]mulrA mulrVK ?unitfE //.
+  rewrite [_ / _ * _]mulrC [in RHS]mulrA [in RHS]mulrA mulfVK//.
   ring.
 set x1 := (- C1 + Num.sqrt (C1 ^+ 2 - 4%:R * (6%:R * g%:num) *
   (- 3%:R * g%:num))) / (2 * (6%:R * g%:num)).
@@ -920,10 +905,10 @@ have circsol s : 0 <= s -> p..[2] ^+ 2 + (sol p s)..[3] ^+ 2 = 1.
   move=> sge0; rewrite -(En0_sol2_const limSKp Epn0 sge0).
   suff [] : K (sol p s) by [].
   exact/subset_limSK_K/limSKinvar.
-set g := fun i : 'I_2 => if i == 0 then Num.sqrt (1 - p..[2] ^+ 2)
+set h := fun i : 'I_2 => if i == 0 then Num.sqrt (1 - p..[2] ^+ 2)
                                    else - (Num.sqrt (1 - p..[2] ^+ 2)).
 rewrite -[p in RHS]sol0.
-apply: (@continuous_finimage_cst (fun t => (sol p t)..[3]) _ g) tge0.
+apply: (@continuous_finimage_cst (fun t => (sol p t)..[3]) _ h) tge0.
   move=> s sge0; apply: (@differentiable_continuous _ R^o R^o).
   have Kp : K p by apply: subset_limSK_K.
   have [_ /(_ _ sge0) sol_ats]:= sol_is_sol sol0 solP Kp.

--- a/pendulum.v
+++ b/pendulum.v
@@ -1,3 +1,4 @@
+From HB Require Import structures.
 From mathcomp Require Import ssreflect ssrfun ssrbool ssrnat eqtype choice seq.
 From mathcomp Require Import order.
 From mathcomp Require Import fintype bigop ssralg ssrnum finmap interval ssrint.
@@ -23,11 +24,8 @@ Lemma ge0_expr_ndecr (R : realDomainType) n (x y : R) :
   0 <= x <= y -> x ^+ n <= y ^+ n.
 Proof.
 move=> /andP [xge0 yge0]; elim: n => [|n ihn]; first by rewrite !expr0.
-by rewrite !exprS ler_pmul // exprn_ge0.
+by rewrite !exprS ler_pM // exprn_ge0.
 Qed.
-
-Lemma mul2r (R : ringType) (x : R) : 2 * x = x + x.
-Proof. by rewrite -mulr2n mulr_natl. Qed.
 
 Section System.
 Context {R : realType}.
@@ -72,8 +70,10 @@ have comp_lin : linear (fun q : 'rV[R]_n.+1 => q..[i] : R^o).
 have comp_cont : continuous (fun q : 'rV[R]_n.+1 => q..[i] : R^o).
   move=> q A [_/posnumP[e] Ae] /=; apply/nbhs_ballP; exists e%:num => //=.
   by move=> r /(_ ord0) /(_ (inZp i)) /Ae.
-apply: DiffDef; first exact: (@linear_differentiable _ _ _ (Linear comp_lin)).
-by rewrite (@diff_lin _ _ _ (Linear comp_lin)).
+pose glM := GRing.isLinear.Build _ _ _ _ _ comp_lin.
+pose gL : {linear 'rV_n.+1 -> R^o} := HB.pack (fun q : 'rV_n.+1 => q ..[ i]) glM.
+apply: DiffDef; first exact: (@linear_differentiable _ _ _ gL).
+by rewrite (@diff_lin _ _ _ gL).
 Qed.
 
 Global Instance is_diff_component_comp (V : normedModType R) n
@@ -110,7 +110,7 @@ Qed.
 
 Lemma V_continuous : continuous V.
 Proof.
-by move=> ?; apply: (@differentiable_continuous _ _ [normedModType R of R^o]).
+by move=> ?; apply: (@differentiable_continuous _ _ R^o).
 Qed.
 
 Variable k0 : R.
@@ -134,7 +134,7 @@ Lemma circle_closed : closed [set p : U | p..[2] ^+ 2 + p..[3] ^+ 2 = 1].
 Proof.
 move=> p clcircp.
 apply/close_eq => //=; first exact: Rhausdorff.
-rewrite (@ball_close _ [normedModType R of R^o]) => e /=.
+rewrite (@ball_close _ R^o) => e /=.
 have : nbhs (p ..[ 2] ^+ 2) (ball (p ..[ 2] ^+ 2) ((e%:num / 2)%:pos)%:num).
   by apply: nbhsx_ballx.
 move=> /expr_continuous [_/posnumP[e1] p2e1_sp2he].
@@ -149,8 +149,8 @@ have [q [circq pme12_q]] :
    by case: ifPn => // ?; apply/nbhsx_ballx.
 rewrite -circq.
 rewrite /ball/=.
-rewrite opprD addrACA; apply: le_lt_trans (ler_norm_add _ _) _.
-by rewrite (splitr e%:num) ltr_add //; [apply/p2e1_sp2he|apply/p3e2_sp3he];
+rewrite opprD addrACA; apply: le_lt_trans (ler_normD _ _) _.
+by rewrite (splitr e%:num) ltrD //; [apply/p2e1_sp2he|apply/p3e2_sp3he];
   apply: le_ball (pme12_q _ _); rewrite le_minl lexx // orbC.
 Qed.
 
@@ -168,7 +168,7 @@ Lemma bounded_poly (a b c d : R) :
 Proof.
 move=> agt0.
 suff ptoinfty : (fun x => a * (x ^+ 2) - (b * `|x|) - c) @ +oo --> +oo.
-  have dleatinfty : [filter of +oo] (>= d).
+  have dleatinfty : +oo (>= d).
     exists d; split => //.
       by rewrite realE; exact: le_total.
     by move=> // ? /ltW.
@@ -182,12 +182,12 @@ have lt0x : 0 < x.
   near: x.
   by exists 0; split => //.
 rewrite ger0_norm ?ltW //; apply: sgtMA.
-rewrite ltr_subr_addr expr2 mulrA -mulrBl; apply: le_lt_trans (ler_norm _) _.
-rewrite -[ `|_|%R]sqr_sqrtr // expr2; apply: ltr_pmul; last 1 first.
+rewrite ltrBrDr expr2 mulrA -mulrBl; apply: le_lt_trans (ler_norm _) _.
+rewrite -[ `|_|%R]sqr_sqrtr // expr2; apply: ltr_pM; last 1 first.
 - by near: x; exists (Num.sqrt `|M + c|); split => //.
 - exact: sqrtr_ge0.
 - exact: sqrtr_ge0.
-rewrite ltr_subr_addr -ltr_pdivr_mull //; near: x.
+rewrite ltrBrDr -ltr_pdivrMl //; near: x.
 exists (a^-1 * (Num.sqrt `|M + c| + b)); split => //.
 rewrite realM//.
   by rewrite realV// realE (ltW agt0).
@@ -217,28 +217,28 @@ have K1bnd : \forall M \near +oo, forall p, K p -> `| p..[1] | < M.
   near=> M => p [_ Vps].
     suff /lt_trans : `| p..[1] | < Num.sqrt (2 * B / kv%:num).
     by apply; near: M; exists (Num.sqrt (2 * B / kv%:num)); split => //.
-  rewrite -sqrtr_sqr ltr_sqrt // mulrAC -ltr_pdivr_mull // invf_div; last first.
+  rewrite -sqrtr_sqr ltr_sqrt // mulrAC -ltr_pdivrMl // invf_div; last first.
     by rewrite mulr0 /B/=.
   apply: le_lt_trans k0_valid; apply: le_trans Vps.
-  by rewrite [V _]addrAC ler_addr addr_ge0 // pmulr_rge0 // sqr_ge0.
+  by rewrite [V _]addrAC lerDr addr_ge0 // pmulr_rge0 // sqr_ge0.
 apply: filter_app (K1bnd); near=> M.
 move=> K1ltM p Kp; have [circp Vps] := Kp; split.
   suff /lt_trans : `| p..[0] | < Num.sqrt (2 * B / kx%:num).
     by apply; near: M; exists (Num.sqrt (2 * B / kx%:num)); split => //.
-  rewrite -sqrtr_sqr ltr_sqrt // mulrAC -ltr_pdivr_mull // invf_div; last first.
+  rewrite -sqrtr_sqr ltr_sqrt // mulrAC -ltr_pdivrMl // invf_div; last first.
     by rewrite mulr0 /B.
   apply: le_lt_trans k0_valid; apply: le_trans Vps.
-  by rewrite ler_addr addr_ge0 // pmulr_rge0 // sqr_ge0.
+  by rewrite lerDr addr_ge0 // pmulr_rge0 // sqr_ge0.
 split; first exact: K1ltM; split.
   suff /le_lt_trans : `| p..[2] | <= 1.
     apply.
     by near: M; exists 1; split => //.
-  by rewrite -sqrtr_sqr -sqrtr1 ler_sqrt // -circp ler_addl sqr_ge0.
+  by rewrite -sqrtr_sqr -sqrtr1 ler_sqrt // -circp lerDl sqr_ge0.
 split.
   suff /le_lt_trans : `| p..[3] | <= 1.
     apply.
     by near: M; exists 1; split => //.
-  by rewrite -sqrtr_sqr -sqrtr1 ler_sqrt // -circp ler_addr sqr_ge0.
+  by rewrite -sqrtr_sqr -sqrtr1 ler_sqrt // -circp lerDr sqr_ge0.
 move: p Kp {circp Vps}; near: M; rewrite /= !near_simpl.
 have [M1 [M1real sgtM1gtK1]] := K1bnd.
 have := bounded_poly (m%:num * l%:num * ((`|M1| + 1) ^+ 2))
@@ -248,46 +248,46 @@ apply: filter_app; near=> M => sEsltM p Kp; have [circp Vps] := Kp.
 apply: sEsltM.
 have : E p < Num.sqrt (2 * B / ke%:num).
   apply: le_lt_trans (ler_norm _) _.
-  rewrite -sqrtr_sqr ltr_sqrt // mulrAC -ltr_pdivr_mull // invf_div; last first.
+  rewrite -sqrtr_sqr ltr_sqrt // mulrAC -ltr_pdivrMl // invf_div; last first.
     by rewrite mulr0 /B.
   apply: le_lt_trans k0_valid; apply: le_trans Vps.
-  by rewrite -[V _]addrA ler_addl addr_ge0 // pmulr_rge0 // sqr_ge0.
-apply: le_lt_trans; apply: ler_add; last first.
-  rewrite -mulrN opprD ler_wpmul2l //.
-  rewrite ler_add2r ler_oppl.
-  rewrite ler_paddl // (le_trans (ler_norm _)) // normrN.
+  by rewrite -[V _]addrA lerDl addr_ge0 // pmulr_rge0 // sqr_ge0.
+apply: le_lt_trans; apply: lerD; last first.
+  rewrite -mulrN opprD ler_wpM2l //.
+  rewrite lerD2r lerNl.
+  rewrite ler_wpDl // (le_trans (ler_norm _)) // normrN.
   rewrite -sqrtr_sqr.
-  by rewrite -sqrtr1 ler_sqrt // -circp ler_addl sqr_ge0.
+  by rewrite -sqrtr1 ler_sqrt // -circp lerDl sqr_ge0.
 rewrite mulrDr [1 / 2 * _ + _]addrC -addrA [1 / 2 * _]mulrCA mul1r mulrA.
 rewrite /=.
-rewrite (expr2 l%:num) ler_add2l; apply: ler_paddl.
+rewrite (expr2 l%:num) lerD2l; apply: ler_wpDl.
   by rewrite pmulr_rge0 // pmulr_rge0 // sqr_ge0.
-rewrite -mulrN -!mulrA ler_wpmul2l // ler_wpmul2l // !mulrN ler_oppl.
+rewrite -mulrN -!mulrA ler_wpM2l // ler_wpM2l // !mulrN lerNl.
 suff : `| p..[1] | * (`| p..[2] | * `| p..[4] |) <=
   (`|M1| + 1) * ((`|M1| + 1) * `| p..[4] |).
   by apply: le_trans; rewrite -!normrM -normrN ler_norm.
-rewrite !mulrA ler_wpmul2r // ler_pmul //.
+rewrite !mulrA ler_wpM2r // ler_pM //.
   apply/ltW/sgtM1gtK1 => //; apply: le_lt_trans (ler_norm _) _.
-  by rewrite ltr_addl.
-have /(le_trans _) : 1 <= `|M1| + 1 by rewrite ler_addr.
-by apply; rewrite -sqrtr_sqr -sqrtr1 ler_sqrt // -circp ler_addl sqr_ge0.
+  by rewrite ltrDl.
+have /(le_trans _) : 1 <= `|M1| + 1 by rewrite lerDr.
+by apply; rewrite -sqrtr_sqr -sqrtr1 ler_sqrt // -circp lerDl sqr_ge0.
 Unshelve. all: by end_near. Qed.
 
 Lemma K_compact : compact K.
 Proof. exact: bounded_closed_compact K_bounded K_closed. Qed.
 
 Lemma Mp_ms_gt0 (p : U) : 0 < M%:num + m%:num * (p..[3] ^+ 2).
-Proof. by rewrite ltr_spaddl // pmulr_rge0 // sqr_ge0. Qed.
+Proof. by rewrite ltr_pwDl // pmulr_rge0 // sqr_ge0. Qed.
 
 Lemma E_small p : V p < B -> `|E p| < kv%:num / (ke%:num * (M%:num + m%:num)).
 Proof.
 move=> Vp_s; rewrite -ltr_sqr ?nnegrE // -normrX ger0_norm ?sqr_ge0 //.
 suff : 2 * (V p) / ke%:num < (kv%:num / (ke%:num * (M%:num + m%:num))) ^+ 2.
   apply: le_lt_trans.
-  rewrite ler_pdivl_mulr // -ler_pdivr_mull // mulrC -mulrA mulrC.
-  by rewrite /V -addrA ler_addl addr_ge0 // pmulr_rge0 // sqr_ge0.
-rewrite ltr_pdivr_mulr // mulrC -ltr_pdivl_mulr // (lt_le_trans Vp_s) //.
-rewrite -mulrA mulrCA mulrA; apply: ler_pmul => //; apply: ler_pmul => //.
+  rewrite ler_pdivlMr // -ler_pdivrMl // mulrC -mulrA mulrC.
+  by rewrite /V -addrA lerDl addr_ge0 // pmulr_rge0 // sqr_ge0.
+rewrite ltr_pdivrMr // mulrC -ltr_pdivlMr // (lt_le_trans Vp_s) //.
+rewrite -mulrA mulrCA mulrA; apply: ler_pM => //; apply: ler_pM => //.
 apply/ge0_expr_ndecr/andP; split; last first.
   by rewrite le_minl/= lexx.
 by rewrite le_minr; apply/andP; split.
@@ -301,14 +301,14 @@ rewrite -[X in X + _](@mulfVK _ ((M%:num + m%:num * (p..[3] ^+ 2)) * ke%:num));
   last by rewrite lt0r_neq0 // pmulr_rgt0 // Mp_ms_gt0.
 rewrite mulrC -mulrDr normrM pmulr_rgt0; last first.
   by rewrite normrM pmulr_rgt0 gtr0_norm // Mp_ms_gt0.
-apply: lt_le_trans (ler_sub_norm_add _ _).
+apply: lt_le_trans (lerB_normD _ _).
 rewrite subr_gt0; apply: lt_le_trans (E_small Vp_s) _.
 rewrite ger0_norm; last first.
   by rewrite pmulr_rge0 // invr_ge0 pmulr_rge0 // Mp_ms_gt0.
-rewrite ler_pmul // lef_pinv ?posrE //; last by rewrite pmulr_rgt0 // Mp_ms_gt0.
-rewrite mulrC ler_pmul //; first exact/ltW/Mp_ms_gt0.
-rewrite ler_add2l -{2}[m%:num]mulr1 ler_pmul // ?sqr_ge0 //.
-by rewrite -circp ler_addr sqr_ge0.
+rewrite ler_pM // lef_pV2 ?posrE //; last by rewrite pmulr_rgt0 // Mp_ms_gt0.
+rewrite mulrC ler_pM //; first exact/ltW/Mp_ms_gt0.
+rewrite lerD2l -{2}[m%:num]mulr1 ler_pM // ?sqr_ge0 //.
+by rewrite -circp lerDr sqr_ge0.
 Qed.
 
 (* TODO: show that Fpendulum is smooth in K and remove these hypotheses using
@@ -375,8 +375,13 @@ rewrite [_ * (_ + _ * x)]mulrDr [_ * (_ * x)]mulrA [_ + _ * x]addrC.
 do 2 rewrite addrA -(mulrDl _ _ x).
 rewrite -!mul2r mul1r mulrDr; do 2 rewrite [2^-1 * _]mulrCA.
 do 2 rewrite [2^-1 * _]mulrA mulVf // mul1r.
-rewrite [_ / _]mulrC ![_ * (_^-1 * _)]mulrA [_ * (_ / _ * _)]mulrA.
-rewrite -[_ + _ + _ * _ * _]addrA -mulrDl.
+rewrite [_ / _]mulrC.
+rewrite ![_ * (_^-1 * _)]mulrA.
+rewrite [_ * (_ / _ * _)]mulrA.
+rewrite -(addrA ((M%:num + m%:num) *
+   (q (inZp 1) *
+    (m%:num * q (inZp 3) * (l%:num * q (inZp 4) ^+ 2 - g%:num * q (inZp 2)) + y)))).
+rewrite -mulrDl.
 rewrite [in _ * x]addrAC ![_ * (_ * (_ + _))]mulrA -mulrDl.
 rewrite -addrA [_ * (_ * (- _ * _))]mulrA -mulrDl.
 apply/(canLR (subrK _))/(canLR (mulfK _)); first by rewrite circp.
@@ -385,7 +390,7 @@ rewrite [(_ + _) * _]mulrDr addrAC [_ + _ * y + _]addrAC.
 apply: (canLR (subrK _)); rewrite -mulrBl [_ * (_ + y)]mulrDr opprD addrA.
 rewrite [_ * (_ - _ * y)]mulrDr addrA -[- (_ * y)]mulNr [_ * (_ * y)]mulrA.
 rewrite [_ + _ * y + _]addrAC; apply: (canLR (subrK _)); rewrite -mulrBl.
-rewrite mulrN opprK mulrACA [_ ^+2 / _]mulrAC mulfVK //.
+rewrite [in RHS]mulrN opprK mulrACA [_ ^+2 / _]mulrAC mulfVK //.
 rewrite [_ / _]mulrC ![_^-1 * _]mulrA [_^-1 * _ * _]mulrC mulVKf //.
 (* was ssring *)admit.
 Admitted.
@@ -436,19 +441,19 @@ have Vsolpinf_geB : B <= V (sol p (inf A)).
       differentiable (V \o sol p : R^o -> R^o) (inf A) by [].
     exact/derivable1_diffP/Vsolp_drvbl.
   have BmVsolps_gt0 : 0 < B - V (sol p (inf A)) by rewrite subr_gt0.
-  have /Vsolp_cont := nbhsx_ballx (V (sol p (inf A))) (PosNum BmVsolps_gt0).
+  have /Vsolp_cont := nbhsx_ballx (V (sol p (inf A))) _ BmVsolps_gt0.
   move=> [_ /posnumP[e] /= infe_Vsolp].
   suff : inf A + e%:num / 2 <= inf A.
-    by rewrite leNgt => /negP; apply; rewrite ltr_addl.
+    by rewrite leNgt => /negP; apply; rewrite ltrDl.
   apply: lb_le_inf An0 _; apply/lbP => s /andP [sge0 Vsolps_geB].
   rewrite leNgt; apply/negP => ltsinfphe; have leinfs : inf A <= s.
     apply: inf_lower_bound => //.
     by rewrite /A/= sge0 Vsolps_geB.
   suff /infe_Vsolp : ball (inf A) e%:num s.
     rewrite /ball/= distrC => /(le_lt_trans (ler_norm _)).
-    by rewrite ltNge => /negP; apply; rewrite ler_sub.
-  rewrite /ball/= distrC ger0_norm ?subr_ge0 // ltr_subl_addl.
-  by apply: lt_trans ltsinfphe _; rewrite ltr_add2l {2}[e%:num]splitr ltr_addl.
+    by rewrite ltNge => /negP; apply; rewrite lerB.
+  rewrite /ball/= distrC ger0_norm ?subr_ge0 // ltrBlDl.
+  by apply: lt_trans ltsinfphe _; rewrite ltrD2l {2}[e%:num]splitr ltrDl.
 have Vsol_drvbl t : t \in `]0, (inf A)[ ->
   is_derive (t : R^o) 1 (V \o sol p : _ -> R^o)
   (- kd%:num * (sol p t)..[1] ^+ 2).
@@ -632,8 +637,8 @@ rewrite /Fpendulum !mxE /= /fctrl; apply: (canLR (subrK _)); rewrite mulrA.
 apply: (canLR (mulfK _)) => //; rewrite [RHS]mulrDl; apply: (canRL (subrK _)).
 rewrite opprD [RHS]mulrDl [RHS]addrC; apply/(canRL (subrK _))/Logic.eq_sym.
 rewrite mulrC -mulNr mulrA mulrA; apply: (canLR (mulfK _)) => //.
-rewrite mulrDr [LHS]mulrDr addrC; apply: (canLR (subrK _)).
-rewrite [LHS]mulrA [LHS]mulrA; apply: (canLR (mulfK _)) => //.
+rewrite [RHS]mulrDr [LHS]mulrDr addrC; apply: (canLR (subrK _)).
+rewrite mulrA -[in X in X / _]mulrA; apply: (canLR (mulfK _)) => //.
 (* was ssring. *)
 admit.
 Admitted.
@@ -728,17 +733,17 @@ have [] := @IVT _ f _ _ ((fl + inf img) / 2) tge0.
   rewrite inE/= in_itv/= => /andP[x0 xt].
   by apply: fcont => //=.
   apply/andP; split.
-    rewrite ler_pdivl_mulr // mulrC mul2r ler_add2l.
+    rewrite ler_pdivlMr // mulrC mul2r lerD2l.
     by apply: lb_le_inf imgn0 _; apply/lbP => ? /andP [/ltW].
-  rewrite ler_pdivr_mulr // mulrC mul2r ler_add //; first exact: ltW.
+  rewrite ler_pdivrMr // mulrC mul2r lerD //; first exact: ltW.
   by apply: inf_lower_bound infimg _ _; apply/andP; split=> //; apply/asboolP.
 move=> s s0t fsemid; suff ltfl_inf : fl < inf img.
   have : inf img <= (fl + inf img) / 2.
     apply: inf_lower_bound (infimg) _ _; apply/andP; split; last first.
       have /finim_f [i] : 0 <= s by rewrite (itvP s0t).
       by rewrite fsemid => midegi; apply/asboolP; exists i.
-    by rewrite ltr_pdivl_mulr // mulrC mul2r ltr_add2l.
-  by rewrite ler_pdivl_mulr // mulrC mul2r ler_add2r leNgt ltfl_inf.
+    by rewrite ltr_pdivlMr // mulrC mul2r ltrD2l.
+  by rewrite ler_pdivlMr // mulrC mul2r lerD2r leNgt ltfl_inf.
 have imgE : img = pred_of_finset [fset x in
   [seq t <- [seq g i | i : 'I_n.+2] | fl < t]]%fset :> set R.
   rewrite funeqE => x; rewrite /img /= /pred_of_finset in_fset/=.
@@ -772,7 +777,11 @@ suff poly_fact : a * (x ^+ 2) + b * x + c = a * (x - x1) * (x - x2).
   by rewrite subr_eq0 => /eqP->; right.
 rewrite /x1 /x2; case: (lerP 0 dlt) => [dltge0|dltlt0].
   rewrite -mulrA mulrBr mulrBl mulrBl opprB addrA [(x * x + _) + _]addrAC.
-  rewrite [_ / _ * x]mulrC -[in RHS]addrA -opprD -mulrDr -mulrDl.
+  rewrite [_ / _ * x]mulrC.
+  rewrite -[in RHS](addrA (x * x + _)).
+  rewrite -(opprD (x * _)).
+  rewrite -mulrDr.
+  rewrite -mulrDl.
   rewrite addrCA -[- b + _ - _]addrA subrr addr0 -mul2r.
   rewrite invrM ?unitfE // [2 * _ * _]mulrC !mulrA mulrVK ?unitfE //.
   rewrite addrAC mulrN opprK !mulrDr mulrA [a * (x / _ * _)]mulrCA !mulrA.
@@ -781,8 +790,9 @@ rewrite /x1 /x2; case: (lerP 0 dlt) => [dltge0|dltlt0].
   rewrite ![_ * - _]mulrC !mulrA !mulrDr -!mulrDl !mulrN !mulNr !opprK.
   rewrite [_ * Num.sqrt _]mulrC -addrA addKr -!expr2 sqr_sqrtr // /dlt.
   rewrite opprD addrA subrr opprK add0r -mulrA -invrM ?unitfE //.
-  rewrite mulrC !mulrA -mulrA -mulrA [a * _]mulrC mulrVK ?unitfE //.
-  by rewrite -natrM -mulrA mulrCA mulVKr // unitfE.
+  rewrite (_ : 4 = 2 * 2); last by rewrite -natrM.
+  rewrite mulrC !mulrA mulVf ?mul1r// (mulrC _ c) -mulrA divff ?mulr1//.
+  by rewrite mulf_eq0 negb_or ane0 pnatr_eq0.
 move: xroot; have -> : a * (x ^+ 2) + b * x + c =
   a * ((x + b / (2 * a)) ^+ 2) + (c - b ^+ 2 / (4%:R * a)).
   rewrite [in RHS]expr2 -mulrA mulrDr mulrDl [c - _]addrC addrA !mulrDr.
@@ -799,12 +809,12 @@ move: xroot; have -> : a * (x ^+ 2) + b * x + c =
 suff : a * (x + b / (2 * a)) ^+ 2 + (c - b ^+ 2 / (4%:R * a)) != 0.
   by move=> pn0 p0; move: pn0; rewrite p0 eq_refl.
 have := ane0; rewrite neq_lt => /orP [alt0|agt0]; last first.
-  apply:lt0r_neq0; rewrite ltr_paddl //; first by rewrite pmulr_rge0 // sqr_ge0.
-  rewrite subr_gt0 ltr_pdivr_mulr; last by rewrite pmulr_rgt0.
+  apply:lt0r_neq0; rewrite ltr_wpDl //; first by rewrite pmulr_rge0 // sqr_ge0.
+  rewrite subr_gt0 ltr_pdivrMr; last by rewrite pmulr_rgt0.
   by rewrite mulrC -subr_lt0.
-rewrite -oppr_eq0 opprD; apply: lt0r_neq0; rewrite ltr_paddl //.
+rewrite -oppr_eq0 opprD; apply: lt0r_neq0; rewrite ltr_wpDl //.
   by rewrite oppr_ge0 nmulr_rle0 // sqr_ge0.
-rewrite oppr_gt0 subr_lt0 ltr_ndivl_mulr; last by rewrite mulrC nmulr_rlt0.
+rewrite oppr_gt0 subr_lt0 ltr_ndivlMr; last by rewrite mulrC nmulr_rlt0.
 by rewrite mulrC -subr_lt0.
 Qed.
 
@@ -820,7 +830,9 @@ have sol32_val : forall s, 0 <= s ->
   move=> s sge0.
   rewrite /C1 /C2 -(Esol_const limSKp sge0) /E /= (sol1_eq0 limSKp sge0)
     -(En0_fctrlsol_const limSKp Epn0 sge0) -(div_fctrl_mP limSKp sge0).
-  rewrite expr0n /= !mulr0 !mul0r add0r addr0 mulrDr mulrA [1 / _]mulrC.
+  rewrite !expr0n /= !mulr0 !mul0r add0r addr0.
+  rewrite (mulrDr 2).
+  rewrite mulrA [1 / _]mulrC.
   rewrite mulVKr ?unitfE // mul1r mulrBr addrC; apply: (canLR (subrK _)).
   rewrite -mulNr mulrDr addrC; apply: (canLR (subrK _)).
   rewrite mulrA; apply: (canLR (mulfK _)) => //.
@@ -856,8 +868,7 @@ set f := fun i : 'I_4 => if i == 0 then - 1 else
                              if i == 2 then x1 else x2.
 rewrite -[p in RHS]sol0.
 apply: (@continuous_finimage_cst (fun s => (sol p s)..[2]) _ f) tge0.
-  move=> s sge0; apply: (@differentiable_continuous _ [normedModType R of R^o]
-    [normedModType R of R^o]).
+  move=> s sge0; apply: (@differentiable_continuous _ R^o R^o).
   have [_ /(_ _ sge0) sol_ats]:= sol_is_sol sol0 solP Kp.
   exact/derivable1_diffP.
 move=> s sge0.
@@ -903,8 +914,7 @@ set g := fun i : 'I_2 => if i == 0 then Num.sqrt (1 - p..[2] ^+ 2)
                                    else - (Num.sqrt (1 - p..[2] ^+ 2)).
 rewrite -[p in RHS]sol0.
 apply: (@continuous_finimage_cst (fun t => (sol p t)..[3]) _ g) tge0.
-  move=> s sge0; apply: (@differentiable_continuous _ [normedModType R of R^o]
-    [normedModType R of R^o]).
+  move=> s sge0; apply: (@differentiable_continuous _ R^o R^o).
   have Kp : K p by apply: subset_limSK_K.
   have [_ /(_ _ sge0) sol_ats]:= sol_is_sol sol0 solP Kp.
   exact/derivable1_diffP.
@@ -966,14 +976,14 @@ rewrite -[X in _ < X]ger0_norm // -ltr_sqr ?nnegrE // -!normrX.
 do 2 rewrite ger0_norm ?sqr_ge0 //.
 suff : 2 * (V (sol p t)) / ke%:num < (2 * m%:num * g%:num * l%:num) ^+ 2.
   apply: le_lt_trans.
-  rewrite -mulrA -ler_pdivr_mull // ler_pdivl_mulr // mulrC mulrA.
-  by rewrite /V -addrA ler_addl addr_ge0 // pmulr_rge0 // sqr_ge0.
-rewrite ltr_pdivr_mulr // -ltr_pdivl_mull // mulrC [_ * ke%:num]mulrC.
+  rewrite -mulrA -ler_pdivrMl // ler_pdivlMr // mulrC mulrA.
+  by rewrite /V -addrA lerDl addr_ge0 // pmulr_rge0 // sqr_ge0.
+rewrite ltr_pdivrMr // -ltr_pdivlMl // mulrC [_ * ke%:num]mulrC.
 have /lt_le_trans : V (sol p t) < B.
   have [_ Vsolp_s] : K (sol p t) by apply/subset_limSK_K/limSKinvar.
   exact: le_lt_trans k0_valid.
-rewrite /B; apply; apply: ler_pmul => //; apply: ler_pmul => //.
-by rewrite ler_expn2r // ?nnegrE // le_minl lexx orbC.
+rewrite /B; apply; apply: ler_pM => //; apply: ler_pM => //.
+by rewrite lerXn2r // ?nnegrE // le_minl lexx orbC.
 Qed.
 
 Lemma subset_limSK_homoclinic_orbit : limS sol K `<=` homoclinic_orbit.

--- a/pendulum.v
+++ b/pendulum.v
@@ -1,25 +1,27 @@
 Require Import Reals.
 From mathcomp Require Import ssreflect ssrfun ssrbool ssrnat eqtype choice seq.
+From mathcomp Require Import order.
 From mathcomp Require Import fintype bigop ssralg ssrnum finmap interval ssrint.
 From mathcomp Require Import matrix zmodp.
-From mathcomp Require Import boolp reals Rstruct Rbar classical_sets posnum.
-From mathcomp Require Import topology normedtype landau derive.
+From mathcomp Require Import boolp reals Rstruct classical_sets posnum.
+From mathcomp Require Import topology normedtype prodnormedzmodule landau derive.
 Require Import lasalle.
 
 Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.
-Import GRing.Theory Num.Def Num.Theory.
+Import GRing.Theory Num.Def Num.Theory Order.POrderTheory Order.TotalTheory.
 
 Local Open Scope classical_set_scope.
+Local Open Scope ring_scope.
 
 Notation "p ..[ i ]" := (p 0 (inZp i)) (at level 10).
 
 Section System.
 
-Parameter m M l g : posreal.
+Parameter m M l g : {posnum R}.
 
-Variable ke kv kx kd : posreal.
+Variable ke kv kx kd : {posnum R}.
 
 Let U := 'rV[R]_5.
 
@@ -56,10 +58,10 @@ Proof.
 have comp_lin : linear (fun q : 'rV[R]_n.+1 => q..[i] : R^o).
   by move=> ???; rewrite !mxE.
 have comp_cont : continuous (fun q : 'rV[R]_n.+1 => q..[i] : R^o).
-  move=> q A [_/posnumP[e] Ae] /=; apply/locallyP; exists e%:num => //.
+  move=> q A [_/posnumP[e] Ae] /=; apply/nbhs_ballP; exists e%:num => //.
   by move=> r /(_ ord0) /(_ (inZp i)) /Ae.
-apply: DiffDef; first exact: (@linear_differentiable _ _ (Linear comp_lin)).
-by rewrite (@diff_lin _ _ (Linear comp_lin)).
+apply: DiffDef; first exact: (@linear_differentiable _ _ _ (Linear comp_lin)).
+by rewrite (@diff_lin _ _ _ (Linear comp_lin)).
 Qed.
 
 Global Instance is_diff_component_comp (V : normedModType R) n
@@ -87,7 +89,7 @@ Global Instance is_derive_component (V : normedModType R) n
   is_derive x v f df -> is_derive x v (fun q => (f q)..[i] : R^o) (df..[i]).
 Proof.
 move=> dfx.
-have diff_f : is_diff (0 : R^o) (fun h => f (h *: v + x)) ( *:%R^~ df ).
+have diff_f : is_diff (0 : [the normedModType _ of R^o]) (fun h => f (h *: v + x)) ( *:%R^~ df ).
   have /derivable1P/derivable1_diffP fdrvbl : derivable f x v by [].
   by apply: DiffDef => //; rewrite diff1E // derive1E -deriveE' derive_val.
 apply: DeriveDef; first exact/derivable1P/derivable1_diffP.
@@ -96,7 +98,7 @@ Qed.
 
 Lemma V_continuous : continuous V.
 Proof.
-by move=> ?; apply: (@differentiable_continuous _ [normedModType R of R^o]).
+by move=> ?; apply: (@differentiable_continuous _ _ [normedModType R of R^o]).
 Qed.
 
 Variable k0 : R.
@@ -119,17 +121,20 @@ Qed.
 Lemma circle_closed : closed [set p : U | p..[2] ^+ 2 + p..[3] ^+ 2 = 1].
 Proof.
 move=> p clcircp.
-apply: (@ball_norm_eq _ [normedModType R of R^o]) => e /=.
+apply/close_eq => //=; first exact: Rhausdorff.
+rewrite (@ball_close _ [normedModType R of R^o]) => e /=.
 have /expr_continuous [_/posnumP[e1] p2e1_sp2he] :=
-  locally_ball (p..[2] ^+ 2) (e%:num / 2)%:pos.
+  nbhsx_ballx (p..[2] ^+ 2) (e%:num / 2)%:pos.
 have /expr_continuous [_ /posnumP[e2] p3e2_sp3he] :=
-  locally_ball (p..[3] ^+ 2) (e%:num / 2)%:pos.
+  nbhsx_ballx (p..[3] ^+ 2) (e%:num / 2)%:pos.
 have [q [circq pme12_q]] :
   [set p : U | p..[2] ^+ 2 + p..[3] ^+ 2 = 1] `&`
-  ball p (minr e1 e2) !=set0 by apply/clcircp/locally_ball.
-rewrite -circq opprD addrACA; apply: ler_lt_trans (ler_normm_add _ _) _.
+  ball p (minr e1%:num e2%:num) !=set0 by apply/clcircp/nbhsx_ballx.
+rewrite -circq.
+rewrite /ball/=.
+rewrite opprD addrACA; apply: le_lt_trans (ler_norm_add _ _) _.
 by rewrite (splitr e%:num) ltr_add //; [apply/p2e1_sp2he|apply/p3e2_sp3he];
-  apply: ball_ler (pme12_q _ _); rewrite ler_minl lerr // orbC.
+  apply: ball_ler (pme12_q _ _); rewrite le_minl lexx // orbC.
 Qed.
 
 Lemma preimV_lek0_closed : closed (V @^-1` (<= k0 : _ -> _)).
@@ -146,31 +151,52 @@ Lemma bounded_poly (a b c d : R) :
 Proof.
 move=> agt0.
 suff ptoinfty : (fun x => a * (x ^+ 2) - (b * `|x|) - c) @ +oo --> +oo.
-  have dleatinfty : [filter of +oo] (>= d) by exists d => ? /ltrW.
-  have /ptoinfty [M1 sgtM1pged] := dleatinfty; near=> M.
-  move=> x pxltd; rewrite ltrNge; apply/negP => Mlex.
-  move: pxltd; rewrite ltrNge => /negP; apply.
+  have dleatinfty : [filter of +oo] (>= d).
+    exists d; split => //.
+      by rewrite realE; exact: le_total.
+    by move=> // ? /ltW.
+  have /ptoinfty [M1 [M1real sgtM1pged]] := dleatinfty; near=> M.
+  move=> x pxltd; rewrite ltNge; apply/negP => Mlex.
+  move: pxltd; rewrite ltNge => /negP; apply.
   rewrite -(@ger0_norm _ `|x|) // -(@ger0_norm _ (_ ^+ 2)) ?sqr_ge0 // normrX.
-  by apply: sgtM1pged; apply: ltr_le_trans Mlex; near: M; exists M1.
-move=> A [M sgtMA]; rewrite !near_simpl; near=> x.
-have lt0x : 0 < x by near: x; exists 0.
-rewrite ger0_norm ?ltrW //; apply: sgtMA.
-rewrite ltr_subr_addr expr2 mulrA -mulrBl; apply: ler_lt_trans (ler_norm _) _.
+  by apply: sgtM1pged; apply: lt_le_trans Mlex; near: M; exists M1.
+move=> A [M [Mreal sgtMA]]; rewrite !near_simpl; near=> x.
+have lt0x : 0 < x.
+  near: x.
+  exists 0; split => //.
+  by rewrite realE lexx.
+rewrite ger0_norm ?ltW //; apply: sgtMA.
+rewrite ltr_subr_addr expr2 mulrA -mulrBl; apply: le_lt_trans (ler_norm _) _.
 rewrite -[ `|_|%R]sqr_sqrtr // expr2; apply: ltr_pmul; last 1 first.
-- by near: x; exists (Num.sqrt `|M + c|).
+- near: x; exists (Num.sqrt `|M + c|); split => //.
+  by rewrite realE sqrtr_ge0.
 - exact: sqrtr_ge0.
 - exact: sqrtr_ge0.
 rewrite ltr_subr_addr -ltr_pdivr_mull //; near: x.
-by exists (a^-1 * (Num.sqrt `|M + c| + b)).
+exists (a^-1 * (Num.sqrt `|M + c| + b)); split => //.
+rewrite realM//.
+  by rewrite realV// realE (ltW agt0).
+rewrite realD//.
+  by rewrite realE sqrtr_ge0.
+by rewrite realE; apply: le_total.
 Grab Existential Variables. all: end_near. Qed.
 
-Lemma K_bounded : bounded K.
+Lemma K_bounded : bounded_set K.
 Proof.
 suff : \forall M \near +oo, forall p, K p -> forall i, `|p ord0 i| < M.
   rewrite /bounded; apply: filter_app; near=> M.
-  move=> Kbnd p /Kbnd ltpM; apply/bigmaxr_ltrP => [|i seqi].
-    by rewrite size_map -cardE card_prod !cardE !size_enum_ord.
-  by rewrite (nth_map 0); [rewrite ord1 ltpM|move: seqi; rewrite size_map].
+  move=> Kbnd /= p /Kbnd ltpM.
+  rewrite /normr/=.
+  rewrite mx_normrE.
+  apply/BigmaxBigminr.bigmaxr_lerP; split => //.
+    near: M.
+    exists 0%R; split.
+      by rewrite realE lexx.
+    by move=> x /ltW.
+  move=> i _.
+  rewrite ord1.
+  apply/ltW.
+  by apply: ltpM.
 suff : \forall M \near +oo, forall p, K p -> `| p..[0] | < M /\
   `| p..[1] | < M /\ `| p..[2] | < M /\ `| p..[3] | < M /\ `| p..[4] | < M.
   apply: filter_app; near=> M.
@@ -179,51 +205,63 @@ suff : \forall M \near +oo, forall p, K p -> `| p..[0] | < M /\
   by move=> n ?; suff : (n.+1.+4 < 5)%N by rewrite !ltnS ltn0.
 have K1bnd : \forall M \near +oo, forall p, K p -> `| p..[1] | < M.
   near=> M => p [_ Vps].
-    suff /ltr_trans : `| p..[1] | < Num.sqrt (2 * B / kv%:num).
-    by apply; near: M; exists (Num.sqrt (2 * B / kv%:num)).
-  rewrite absRE -sqrtr_sqr ltr_sqrt // mulrAC -ltr_pdivr_mull // invf_div.
-  apply: ler_lt_trans k0_valid; apply: ler_trans Vps.
+    suff /lt_trans : `| p..[1] | < Num.sqrt (2 * B / kv%:num).
+    apply; near: M; exists (Num.sqrt (2 * B / kv%:num)); split => //.
+    by rewrite realE sqrtr_ge0.
+  rewrite -sqrtr_sqr ltr_sqrt // mulrAC -ltr_pdivr_mull // invf_div.
+  apply: le_lt_trans k0_valid; apply: le_trans Vps.
   by rewrite [V _]addrAC ler_addr addr_ge0 // pmulr_rge0 // sqr_ge0.
 apply: filter_app (K1bnd); near=> M.
 move=> K1ltM p Kp; have [circp Vps] := Kp; split.
-  suff /ltr_trans : `| p..[0] | < Num.sqrt (2 * B / kx%:num).
-    by apply; near: M; exists (Num.sqrt (2 * B / kx%:num)).
-  rewrite absRE -sqrtr_sqr ltr_sqrt // mulrAC -ltr_pdivr_mull // invf_div.
-  apply: ler_lt_trans k0_valid; apply: ler_trans Vps.
+  suff /lt_trans : `| p..[0] | < Num.sqrt (2 * B / kx%:num).
+    apply; near: M; exists (Num.sqrt (2 * B / kx%:num)); split => //.
+    by rewrite realE sqrtr_ge0.
+  rewrite -sqrtr_sqr ltr_sqrt // mulrAC -ltr_pdivr_mull // invf_div.
+  apply: le_lt_trans k0_valid; apply: le_trans Vps.
   by rewrite ler_addr addr_ge0 // pmulr_rge0 // sqr_ge0.
 split; first exact: K1ltM; split.
-  suff /ler_lt_trans : `| p..[2] | <= 1 by apply; near: M; exists 1.
-  by rewrite absRE -sqrtr_sqr -sqrtr1 ler_sqrt // -circp ler_addl sqr_ge0.
+  suff /le_lt_trans : `| p..[2] | <= 1.
+    apply.
+    near: M; exists 1; split => //.
+    by rewrite realE ler01.
+  by rewrite -sqrtr_sqr -sqrtr1 ler_sqrt // -circp ler_addl sqr_ge0.
 split.
-  suff /ler_lt_trans : `| p..[3] | <= 1 by apply; near: M; exists 1.
-  by rewrite absRE -sqrtr_sqr -sqrtr1 ler_sqrt // -circp ler_addr sqr_ge0.
+  suff /le_lt_trans : `| p..[3] | <= 1.
+    apply.
+    near: M; exists 1; split => //.
+    by rewrite realE ler01.
+  by rewrite -sqrtr_sqr -sqrtr1 ler_sqrt // -circp ler_addr sqr_ge0.
 move: p Kp {circp Vps}; near: M; rewrite /= !near_simpl.
-have [M1 sgtM1gtK1] := K1bnd.
+have [M1 [M1real sgtM1gtK1]] := K1bnd.
 have := bounded_poly (m%:num * l%:num * ((`|M1| + 1) ^+ 2))
   (m%:num * l%:num * g%:num * ((`|M1| + 1) + 1)) (Num.sqrt (2 * B / ke%:num))
   [gt0 of m%:num * (l%:num ^+ 2) / 2].
 apply: filter_app; near=> M => sEsltM p Kp; have [circp Vps] := Kp.
 apply: sEsltM.
 have : E p < Num.sqrt (2 * B / ke%:num).
-  apply: ler_lt_trans (ler_norm _) _.
+  apply: le_lt_trans (ler_norm _) _.
   rewrite -sqrtr_sqr ltr_sqrt // mulrAC -ltr_pdivr_mull // invf_div.
-  apply: ler_lt_trans k0_valid; apply: ler_trans Vps.
+  apply: le_lt_trans k0_valid; apply: le_trans Vps.
   by rewrite -[V _]addrA ler_addl addr_ge0 // pmulr_rge0 // sqr_ge0.
-apply: ler_lt_trans; apply: ler_add; last first.
-  rewrite -mulrN opprD ler_wpmul2l // ler_add2r ler_oppl.
-  rewrite ler_paddl // (ler_trans (ler_norm _)) // normrN.
-  by rewrite -sqrtr_sqr -sqrtr1 ler_sqrt // -circp ler_addl sqr_ge0.
+apply: le_lt_trans; apply: ler_add; last first.
+  rewrite -mulrN opprD ler_wpmul2l //.
+    by rewrite !RmultE.
+  rewrite ler_add2r ler_oppl.
+  rewrite ler_paddl // (le_trans (ler_norm _)) // normrN.
+  rewrite -sqrtr_sqr.
+  rewrite (_ : 1%coqR = 1)//.
+  by rewrite -sqrtr1 ler_sqrt // -circp ler_addl sqr_ge0.
 rewrite mulrDr [1 / 2 * _ + _]addrC -addrA [1 / 2 * _]mulrCA mul1r mulrA.
 rewrite (expr2 l%:num) ler_add2l; apply: ler_paddl.
   by rewrite pmulr_rge0 // pmulr_rge0 // sqr_ge0.
 rewrite -mulrN -!mulrA ler_wpmul2l // ler_wpmul2l // !mulrN ler_oppl.
 suff : `| p..[1] | * (`| p..[2] | * `| p..[4] |) <=
   (`|M1| + 1) * ((`|M1| + 1) * `| p..[4] |).
-  by apply: ler_trans; rewrite -!normrM -normrN ler_norm.
+  by apply: le_trans; rewrite -!normrM -normrN ler_norm.
 rewrite !mulrA ler_wpmul2r // ler_pmul //.
-  apply/ltrW/sgtM1gtK1 => //; apply: ler_lt_trans (ler_norm _) _.
+  apply/ltW/sgtM1gtK1 => //; apply: le_lt_trans (ler_norm _) _.
   by rewrite ltr_addl.
-have /(ler_trans _) : 1 <= `|M1| + 1 by rewrite ler_addr.
+have /(le_trans _) : 1 <= `|M1| + 1 by rewrite ler_addr.
 by apply; rewrite -sqrtr_sqr -sqrtr1 ler_sqrt // -circp ler_addl sqr_ge0.
 Unshelve. all: end_near. Grab Existential Variables. all: end_near. Qed.
 
@@ -244,13 +282,14 @@ Lemma E_small p : V p < B -> `|E p| < kv%:num / (ke%:num * (M%:num + m%:num)).
 Proof.
 move=> Vp_s; rewrite -ltr_sqr ?nnegrE // -normrX ger0_norm ?sqr_ge0 //.
 suff : 2 * (V p) / ke%:num < (kv%:num / (ke%:num * (M%:num + m%:num))) ^+ 2.
-  apply: ler_lt_trans.
+  apply: le_lt_trans.
   rewrite ler_pdivl_mulr // -ler_pdivr_mull // mulrC -mulrA mulrC.
   by rewrite /V -addrA ler_addl addr_ge0 // pmulr_rge0 // sqr_ge0.
-rewrite ltr_pdivr_mulr // mulrC -ltr_pdivl_mulr // (ltr_le_trans Vp_s) //.
+rewrite ltr_pdivr_mulr // mulrC -ltr_pdivl_mulr // (lt_le_trans Vp_s) //.
 rewrite -mulrA mulrCA mulrA; apply: ler_pmul => //; apply: ler_pmul => //.
-apply/ge0_expr_ndecr/andP; split; last by rewrite ler_minl lerr.
-by rewrite ler_minr; apply/andP; split.
+apply/ge0_expr_ndecr/andP; split; last first.
+  by rewrite le_minl/= lexx.
+by rewrite le_minr; apply/andP; split.
 Qed.
 
 Lemma fctrl_wdef (p : U) : (p..[2] ^+ 2) + (p..[3] ^+ 2) = 1 -> V p < B ->
@@ -261,12 +300,12 @@ rewrite -[X in X + _](@mulfVK _ ((M%:num + m%:num * (p..[3] ^+ 2)) * ke%:num));
   last by rewrite lt0r_neq0 // pmulr_rgt0 // Mp_ms_gt0.
 rewrite mulrC -mulrDr normrM pmulr_rgt0; last first.
   by rewrite normrM pmulr_rgt0 gtr0_norm // Mp_ms_gt0.
-apply: ltr_le_trans (ler_sub_norm_add _ _).
-rewrite subr_gt0; apply: ltr_le_trans (E_small Vp_s) _.
+apply: lt_le_trans (ler_sub_norm_add _ _).
+rewrite subr_gt0; apply: lt_le_trans (E_small Vp_s) _.
 rewrite ger0_norm; last first.
   by rewrite pmulr_rge0 // invr_ge0 pmulr_rge0 // Mp_ms_gt0.
 rewrite ler_pmul // lef_pinv ?posrE //; last by rewrite pmulr_rgt0 // Mp_ms_gt0.
-rewrite mulrC ler_pmul //; first exact/ltrW/Mp_ms_gt0.
+rewrite mulrC ler_pmul //; first exact/ltW/Mp_ms_gt0.
 rewrite ler_add2l -{2}[m%:num]mulr1 ler_pmul // ?sqr_ge0 //.
 by rewrite -circp ler_addr sqr_ge0.
 Qed.
@@ -283,10 +322,10 @@ Lemma eq0_derive1_cst (f : R^o -> R^o) (a b : R) :
   (forall t, t \in `[a, b] -> is_derive (t : R^o) 1 f 0) ->
   forall t, t \in `[a, b] -> f t = f a.
 Proof.
-move=> f'eq0 t tab; apply/eqP; rewrite eqr_le; apply/andP; split.
-  by apply: (@ler0_derive1_nincr _ a b) => //; rewrite ?(itvP tab) //;
+move=> f'eq0 t tab; apply/eqP; rewrite eq_le; apply/andP; split.
+  by apply: (@ler0_derive1_nincr _ _ a b) => //; rewrite ?(itvP tab) //;
     move=> ? /f'eq0 // df; rewrite derive1E derive_val.
-by apply: (@le0r_derive1_ndecr _ a b) => //; rewrite ?(itvP tab) //;
+by apply: (@le0r_derive1_ndecr _ _ a b) => //; rewrite ?(itvP tab) //;
   move=> ? /f'eq0 // df; rewrite derive1E derive_val.
 Qed.
 
@@ -296,7 +335,7 @@ Proof.
 move=> Kp /= t tge0; have [circp _] := Kp; rewrite -circp -[in RHS](sol0 p).
 pose f s := (sol p s)..[2] ^+ 2 + (sol p s)..[3] ^+ 2; rewrite -!/(f _).
 (* BUG in unification *)
-apply (@eq0_derive1_cst (f : R^o -> R^o) 0 t); last by rewrite inE/= lerr tge0.
+apply (@eq0_derive1_cst (f : R^o -> R^o) 0 t); last by rewrite inE/= lexx tge0.
 move=> s s0t; have sge0 : s >= 0 by rewrite (itvP s0t).
 have [_ /(_ _ sge0) dsol] := sol_is_sol sol0 solP Kp.
 apply: is_derive_eq.
@@ -367,12 +406,13 @@ Lemma defset_invar p : K p -> forall t, 0 <= t ->
   (sol p t)..[2] ^+ 2 + (sol p t)..[3] ^+ 2 = 1 /\ V (sol p t) < B.
 Proof.
 move=> Kp t tge0; split; first exact: circ_invar.
-set A := [pred t | (0 <= t) && (B <= V (sol p t))].
-case: (pselect (reals.nonempty A))=> [An0 |]; last first.
-  by move=> /asboolPn /forallp_asboolPn /(_ t) /negP; rewrite inE => /nandP [];
-    [rewrite tge0|rewrite -ltrNge].
+set A := [set t | (0 <= t) && (B <= V (sol p t))].
+case: (pselect (nonempty A))=> [An0 |]; last first.
+  move=> /asboolPn /forallp_asboolPn /(_ t) /negP.
+  by move => /nandP [];
+    [rewrite tge0|rewrite -ltNge].
 have infA : has_inf A.
-  by apply/has_infP; split=> //; exists 0; apply/lbP => ? /andP [].
+  by split=> //; exists 0; apply/lbP => ? /andP [].
 exfalso=> {t tge0}; have infge0 : 0 <= inf A.
   by apply: lb_le_inf => //; apply/lbP => ? /andP [].
 have Vsolp_drvbl t : 0 <= t -> derivable (V \o (sol p) : R^o -> R^o) t 1.
@@ -384,42 +424,43 @@ have Vsolpinf_geB : B <= V (sol p (inf A)).
       differentiable (V \o sol p : R^o -> R^o) (inf A) by [].
     exact/derivable1_diffP/Vsolp_drvbl.
   have BmVsolps_gt0 : 0 < B - V (sol p (inf A)) by rewrite subr_gt0.
-  have /Vsolp_cont := locally_ball (V (sol p (inf A))) (PosNum BmVsolps_gt0).
+  have /Vsolp_cont := nbhsx_ballx (V (sol p (inf A))) (PosNum BmVsolps_gt0).
   move=> [_ /posnumP[e] /= infe_Vsolp].
   suff : inf A + e%:num / 2 <= inf A.
-    by rewrite lerNgt => /negP; apply; rewrite ltr_addl.
+    by rewrite leNgt => /negP; apply; rewrite ltr_addl.
   apply: lb_le_inf An0 _; apply/lbP => s /andP [sge0 Vsolps_geB].
-  rewrite lerNgt; apply/negP => ltsinfphe; have leinfs : inf A <= s.
-    by apply: inf_lower_bound => //; rewrite inE sge0 Vsolps_geB.
+  rewrite leNgt; apply/negP => ltsinfphe; have leinfs : inf A <= s.
+    apply: inf_lower_bound => //.
+    by rewrite /A sge0 Vsolps_geB.
   suff /infe_Vsolp : ball (inf A) e%:num s.
-    rewrite ball_absE /= absrB absRE => /(ler_lt_trans (ler_norm _)).
-    by rewrite ltrNge => /negP; apply; rewrite ler_sub.
-  rewrite ball_absE /= absrB absRE ger0_norm ?subr_ge0 // ltr_subl_addl.
-  by apply: ltr_trans ltsinfphe _; rewrite ltr_add2l {2}[e%:num]splitr ltr_addl.
+    rewrite /ball/= distrC => /(le_lt_trans (ler_norm _)).
+    by rewrite ltNge => /negP; apply; rewrite ler_sub.
+  rewrite /ball/= distrC ger0_norm ?subr_ge0 // ltr_subl_addl.
+  by apply: lt_trans ltsinfphe _; rewrite ltr_add2l {2}[e%:num]splitr ltr_addl.
 have Vsol_drvbl t : t \in `]0, (inf A)[ ->
   is_derive (t : R^o) 1 (V \o sol p : _ -> R^o)
   (- kd%:num * (sol p t)..[1] ^+ 2).
   move=> t0inf; apply: is_deriv_Vsol => //; first by rewrite (itvP t0inf).
-  rewrite ltrNge; apply/negP => Vsolpt_geB; suff : inf A <= t.
-    by rewrite lerNgt => /negP; apply; rewrite (itvP t0inf).
-  apply: inf_lower_bound => //; rewrite inE; apply/andP; split=> //.
+  rewrite ltNge; apply/negP => Vsolpt_geB; suff : inf A <= t.
+    by rewrite leNgt => /negP; apply; rewrite (itvP t0inf).
+  apply: inf_lower_bound => //; apply/andP; split=> //.
   by rewrite (itvP t0inf).
 have : {in `[0, (inf A)], continuous (V \o sol p)}.
   move=> t t0inf; suff /differentiable_continuous :
     differentiable (V \o sol p : R^o -> R^o) t by [].
   by apply/derivable1_diffP/Vsolp_drvbl; rewrite (itvP t0inf).
 move=> /(MVT infge0 Vsol_drvbl) [t t0inf].
-rewrite /funcomp sol0 subr0 => dVsol.
+rewrite /comp sol0 subr0 => dVsol.
 have infgt0 : 0 < inf A.
-  rewrite ltr_def; apply/andP; split=> //.
+  rewrite lt_def; apply/andP; split=> //.
   apply/negP => /eqP infA0; have := Vsolpinf_geB.
-  rewrite lerNgt => /negP; apply; rewrite infA0 sol0.
-  by apply: ler_lt_trans k0_valid; have [] := Kp.
+  rewrite leNgt => /negP; apply; rewrite infA0 sol0.
+  by apply: le_lt_trans k0_valid; have [] := Kp.
 have : V (sol p (inf A)) - V p <= 0.
   by rewrite dVsol !mulNr oppr_le0 pmulr_lge0 // pmulr_rge0 // sqr_ge0.
-rewrite lerNgt => /negP; apply.
-rewrite subr_gt0; apply: ltr_le_trans Vsolpinf_geB.
-by apply: ler_lt_trans k0_valid; have [] := Kp.
+rewrite leNgt => /negP; apply.
+rewrite subr_gt0; apply: lt_le_trans Vsolpinf_geB.
+by apply: le_lt_trans k0_valid; have [] := Kp.
 Qed.
 
 Lemma is_derive_Vsol p (t : R^o) :
@@ -433,11 +474,11 @@ Qed.
 Lemma Kinvar : is_invariant sol K.
 Proof.
 move=> p Kp t tge0; have [_ Vp_s] := Kp; split; first exact: circ_invar.
-apply: ler_trans Vp_s; rewrite -{2}[p]sol0.
+apply: le_trans Vp_s; rewrite -{2}[p]sol0.
 have Vsol_deriv : forall s, s \in `[0, t] ->
   is_derive (s : R^o) 1 (V \o sol p : _ -> R^o)
   (- kd%:num * (sol p s)..[1] ^+ 2) by move=> s /andP [/(is_derive_Vsol Kp)].
-apply: (@ler0_derive1_nincr (V \o sol p) 0 t);[idtac|idtac|by [] |by [] |by []].
+apply: (@ler0_derive1_nincr _ (V \o sol p) 0 t);[idtac|idtac|by [] |by [] |by []].
   by move=> ? /Vsol_deriv.
 move=> s /Vsol_deriv dVsols; rewrite derive1E derive_val.
 by rewrite !mulNr oppr_le0 pmulr_rge0 // sqr_ge0.
@@ -470,8 +511,11 @@ Qed.
 Lemma subset_limSK_K : limS sol K `<=` K.
 Proof.
 move=> p [q Kq solq_top].
-apply: compact_closed (@normedModType_hausdorff _ _) K_compact _ _.
-have solqK : (sol q @ +oo) K by exists 0 => ? /ltrW; apply: Kinvar.
+apply: compact_closed (@norm_hausdorff _ _) K_compact _ _.
+have solqK : (sol q @ +oo) K.
+  exists 0; split.
+    by rewrite realE lexx.
+  by move=> ? /ltW; apply: Kinvar.
 by move=> A /solq_top - /(_ _ solqK) [r []]; exists r.
 Qed.
 
@@ -484,13 +528,15 @@ have -> : derive1 (V \o sol p : _ -> R^o) t =
   derive1 (V \o sol (sol p t) : _ -> R^o) 0.
   have dVsolt := is_derive_Vsol Kp tge0; rewrite derive1E derive_val.
   have Ksolpt : K (sol p t) by apply: subset_limSK_K.
-  have dVsolt' := is_derive_Vsol Ksolpt (lerr _); rewrite derive1E derive_val.
-  by rewrite -(solD sol0 solP Kinvar) // add0r.
+  have dVsolt' := is_derive_Vsol Ksolpt (lexx _); rewrite derive1E derive_val.
+  rewrite -(solD sol0 solP Kinvar) //.
+  rewrite RplusE.
+  by rewrite add0r.
 apply: (stable_limS K_compact sol0 solP sol_cont Kinvar (V:=V)) limSKsolp.
-- move=> q Kq; have /(_ q) := V_continuous; apply: flim_trans.
-  exact: flim_app (@flim_within _ _ _ _).
+- move=> q Kq; have /(_ q) := V_continuous; apply: cvg_trans.
+  exact: cvg_app (@cvg_within _ _ _ _).
 - by move=> q s Kq sge0; have := is_derive_Vsol Kq sge0.
-- move=> q Kq; have dVsolq := is_derive_Vsol Kq (lerr _).
+- move=> q Kq; have dVsolq := is_derive_Vsol Kq (lexx _).
   by rewrite derive1E derive_val mulNr oppr_le0 pmulr_rge0 // sqr_ge0.
 Qed.
 
@@ -510,10 +556,13 @@ move=> feg tge0 df dg.
 have /@derive_val <- := df; have /@derive_val <- := dg.
 apply: subr0_eq; rewrite -deriveB // /derive cvg_at_rightE; last first.
   by rewrite -[cvg _]/(derivable _ _ _).
-apply: flim_map_lim => A A0; rewrite !near_simpl; near=> h.
+apply: cvg_map_lim => A A0.
+  rewrite -close_cluster.
+  by rewrite norm_closeE.
+rewrite !near_simpl; near=> h.
 rewrite /= -![(_ - _ : _ -> _) _]/(_ - _) !feg //.
-  by rewrite !subrr scaler0; apply: locally_singleton.
-by rewrite addr_ge0 // [_%:A]mulr1 ltrW //; near: h; exists 1.
+  by rewrite !subrr scaler0; apply: nbhs_singleton.
+by rewrite addr_ge0 // [_%:A]mulr1 ltW //; near: h; exists 1.
 Grab Existential Variables. all: end_near. Qed.
 
 Lemma sol1'_eq0 p t : limS sol K p -> 0 <= t -> (Fpendulum (sol p t))..[1] = 0.
@@ -528,7 +577,7 @@ Lemma sol0_const p t : limS sol K p -> 0 <= t -> (sol p t)..[0] = p..[0].
 Proof.
 move=> limSKp tge0; rewrite -[p in RHS]sol0.
 apply (@eq0_derive1_cst (fun s => (sol p s)..[0]) 0 t); last first.
-  by rewrite inE/= lerr tge0.
+  by rewrite inE/= lexx tge0.
 move=> s /andP [sge0 _]; have /subset_limSK_K Kp := limSKp.
 have [_ /(_ _ sge0) /(is_derive_component 0) dsol0] := sol_is_sol sol0 solP Kp.
 by apply: DeriveDef => //; rewrite derive_val mxE /= sol1_eq0.
@@ -538,7 +587,7 @@ Lemma Esol_const p t : limS sol K p -> 0 <= t -> (E \o sol p) t = E p.
 Proof.
 move=> limSKp tge0; rewrite -[p in RHS]sol0.
 apply (@eq0_derive1_cst (E \o sol p) 0 t); last first.
-  by rewrite inE/= lerr tge0.
+  by rewrite inE/= lexx tge0.
 move=> s /andP [sge0 _]; have /subset_limSK_K Kp := limSKp.
 have dEsol := is_derive_Esol Kp sge0; apply: DeriveDef => //.
 by rewrite derive_val sol1_eq0 // mul0r.
@@ -551,7 +600,7 @@ move=> limSKp tge0.
 have -> :
   0 = - (kd%:num * (sol p t)..[1] + kv%:num * (Fpendulum (sol p t))..[1]).
   by rewrite sol1'_eq0 // sol1_eq0 // !mulr0 add0r oppr0.
-have [circsolt /ler_lt_trans /(_ k0_valid) Vsolts] : K (sol p t).
+have [circsolt /le_lt_trans /(_ k0_valid) Vsolts] : K (sol p t).
   by apply: Kinvar tge0; apply: subset_limSK_K.
 have fctrl_def := fctrl_wdef circsolt Vsolts.
 have Mpmsne0 : M%:num + m%:num * (sol p t)..[3] ^+ 2 != 0.
@@ -596,7 +645,7 @@ Lemma En0_fctrlsol_const p t :
 Proof.
 move=> limSKp Epn0 tge0.
 have := Efctrl_psol0_eq0 limSKp tge0.
-rewrite -(Efctrl_psol0_eq0 limSKp (lerr _)) sol0
+rewrite -(Efctrl_psol0_eq0 limSKp (lexx _)) sol0
   [E (sol p t)](Esol_const limSKp tge0) (sol0_const limSKp tge0).
 have keEn0 : ke%:num * E p != 0 by rewrite mulrI_eq0 //; apply/lregP.
 move/(canRL (addrK _)); rewrite -addrA subrr addr0 mulrC.
@@ -604,21 +653,23 @@ by move=> /(canRL (mulfK _)) - /(_ keEn0) ->; rewrite mulrAC -mulrA mulVKf.
 Qed.
 
 Lemma inf_in_finset (A : {fset R}) :
-  has_inf [pred t | t \in A] -> inf [pred t | t \in A] \in A.
+  has_inf [set t | t \in A] -> inf [set t | t \in A] \in A.
 Proof.
-move=> infA; have /has_infP [[t At] _] := infA.
+move=> infA; have [[t At] _] := infA.
 have Amin : \big[minr/t]_(s <- enum_fset A) s \in A.
   have : forall s, s \in enum_fset A -> s \in A by [].
   elim: (enum_fset A) => [inA|s l ihl inA]; first by rewrite big_nil.
-  rewrite big_cons; case: minrP => _; first by apply: inA; rewrite inE eq_refl.
+  rewrite big_cons.
+  have [sl|sl] := leP s _.
+    by apply: inA; rewrite mem_head.
   by apply: ihl => r lr; apply: inA; rewrite inE orbC lr.
-suff -> : inf [pred t | t \in A] = \big[minr/t]_(s <- enum_fset A) s by [].
-apply/eqP; rewrite eqr_le; apply/andP; split; first exact: inf_lower_bound Amin.
-apply: lb_le_inf; first by have /has_infP [] := infA.
+suff -> : inf [set t | t \in A] = \big[minr/t]_(s <- enum_fset A) s by [].
+apply/eqP; rewrite eq_le; apply/andP; split; first exact: inf_lower_bound Amin.
+apply: lb_le_inf; first by have [] := infA.
 apply/lbP => s As; have : s \in enum_fset A by [].
 elim: (enum_fset A) => // r l ihl; rewrite inE => /orP [/eqP <-|].
-  by rewrite big_cons ler_minl lerr.
-by rewrite big_cons ler_minl orbC => /ihl ->.
+  by rewrite big_cons le_minl lexx.
+by rewrite big_cons le_minl orbC => /ihl ->.
 Qed.
 
 Lemma continuous_finimage_cst (f : R -> R) n (g : 'I_n -> R) :
@@ -628,29 +679,33 @@ Lemma continuous_finimage_cst (f : R -> R) n (g : 'I_n -> R) :
 Proof.
 case: n g => [g ? finim_f t tge0|]; first by have /finim_f [] := tge0; case.
 case=> [|n] g fcont finim_f t tge0.
-  have /finim_f [i ->] := tge0; have /finim_f [j ->] := lerr (0 : R).
+  have /finim_f [i ->] := tge0; have /finim_f [j ->] := lexx (0 : R).
   by rewrite !ord1.
 case: (eqVneq (f t) (f 0)) => // ftnef0.
 set fl := minr (f 0) (f t); set fr := maxr (f 0) (f t).
 have ltflr : fl < fr.
-  rewrite /fr; case: maxrP => [left0|ltf0t].
-    by rewrite /fl minr_r // ltr_def eq_sym ftnef0 left0.
-  by rewrite /fl minr_l // ltrW.
-set img := [pred x | (fl < x) && (x \in g @` setT)].
+  rewrite /fr.
+  have [left0|lt0ft] := leP (f 0) _.
+    rewrite /fl; move: (left0) => /min_idPl => ->.
+    by rewrite lt_def ftnef0/= left0.
+  by rewrite /fl; move/ltW: (lt0ft) => /min_idPr => ->.
+set img := [set x | (fl < x) && (x \in g @` setT)].
 have imgfr : (g @` setT) fr.
-  rewrite /fr; case: maxrP => _.
-    by have /finim_f [i] := lerr (0 : R); exists i.
-  by have /finim_f [i] := tge0; exists i.
-have imgn0 : reals.nonempty img.
-  by exists fr; rewrite !inE ltflr andTb; apply/asboolP.
+  rewrite /fr.
+  have [f0ft|f0ft] := leP (f 0) (f t).
+    by have /finim_f [i] := tge0; exists i.
+  by have /finim_f [i] := lexx (0 : R); exists i.
+have imgn0 : nonempty img.
+  exists fr.
+  by rewrite /img ltflr andTb; apply/asboolP.
 have infimg : has_inf img.
-  by apply/has_infP; split=> //; exists fl; apply/lbP => ? /andP [/ltrW].
-have [] := @IVT f _ _ ((fl + inf img) / 2) tge0.
+  by split=> //; exists fl; apply/lbP => ? /andP [/ltW].
+have [] := @IVT _ f _ _ ((fl + inf img) / 2) tge0.
     by move=> s s0t; apply: fcont; rewrite [_ \in _](itvP s0t).
   apply/andP; split.
     rewrite ler_pdivl_mulr // mulrC mul2r ler_add2l.
-    by apply: lb_le_inf imgn0 _; apply/lbP => ? /andP [/ltrW].
-  rewrite ler_pdivr_mulr // mulrC mul2r ler_add //; first exact: ltrW.
+    by apply: lb_le_inf imgn0 _; apply/lbP => ? /andP [/ltW].
+  rewrite ler_pdivr_mulr // mulrC mul2r ler_add //; first exact: ltW.
   by apply: inf_lower_bound infimg _ _; apply/andP; split=> //; apply/asboolP.
 move=> s s0t fsemid; suff ltfl_inf : fl < inf img.
   have : inf img <= (fl + inf img) / 2.
@@ -658,16 +713,19 @@ move=> s s0t fsemid; suff ltfl_inf : fl < inf img.
       have /finim_f [i] : 0 <= s by rewrite (itvP s0t).
       by rewrite fsemid => midegi; apply/asboolP; exists i.
     by rewrite ltr_pdivl_mulr // mulrC mul2r ltr_add2l.
-  by rewrite ler_pdivl_mulr // mulrC mul2r ler_add2r lerNgt ltfl_inf.
+  by rewrite ler_pdivl_mulr // mulrC mul2r ler_add2r leNgt ltfl_inf.
 have imgE : img = pred_of_finset [fset x in
-  [seq t <- [seq g i | i : 'I_n.+2] | fl < t]]%fset :> pred R.
-  rewrite funeqE => x; rewrite /img /= /pred_of_finset in_fset.
-  apply: (@sameP ((fl < x) /\ x \in (g @` setT))); first exact: andP.
-  apply: (iffP idP) => [|[ltflx /asboolP [i _ giex]]].
-    rewrite mem_filter => /andP [ltflx /mapP [i _ xegi]]; split=> //.
-    by apply/asboolP; exists i.
-  rewrite mem_filter ltflx andTb; apply/mapP; exists i => //.
-  by rewrite enumT.
+  [seq t <- [seq g i | i : 'I_n.+2] | fl < t]]%fset :> set R.
+  rewrite funeqE => x; rewrite /img /= /pred_of_finset in_fset/=.
+  apply/propext; split.
+    rewrite mem_filter => /andP[flx].
+    rewrite inE => -[i _ gix].
+    rewrite flx/=.
+    apply/mapP; exists i => //=.
+    by rewrite mem_enum.
+  rewrite mem_filter/= => /andP[flx /mapP[/= i _ xgi]].
+  rewrite flx/= xgi.
+  by apply/asboolP; exists i.
 rewrite imgE; set A := [fset x in _]%fset.
 have : inf (pred_of_finset A) \in A.
   by apply: inf_in_finset; rewrite -[X in has_inf X]imgE.
@@ -715,7 +773,7 @@ move: xroot; have -> : a * (x ^+ 2) + b * x + c =
   by rewrite -natrM subrr !mulr0.
 suff : a * (x + b / (2 * a)) ^+ 2 + (c - b ^+ 2 / (4%:R * a)) != 0.
   by move=> pn0 p0; move: pn0; rewrite p0 eq_refl.
-have := ane0; rewrite neqr_lt => /orP [alt0|agt0]; last first.
+have := ane0; rewrite neq_lt => /orP [alt0|agt0]; last first.
   apply:lt0r_neq0; rewrite ltr_paddl //; first by rewrite pmulr_rge0 // sqr_ge0.
   rewrite subr_gt0 ltr_pdivr_mulr; last by rewrite pmulr_rgt0.
   by rewrite mulrC -subr_lt0.
@@ -773,7 +831,7 @@ set f := fun i : 'I_4 => if i == 0 then - 1 else
                              if i == 2 then x1 else x2.
 rewrite -[p in RHS]sol0.
 apply: (@continuous_finimage_cst (fun s => (sol p s)..[2]) _ f) tge0.
-  move=> s sge0; apply: (@differentiable_continuous [normedModType R of R^o]
+  move=> s sge0; apply: (@differentiable_continuous _ [normedModType R of R^o]
     [normedModType R of R^o]).
   have [_ /(_ _ sge0) sol_ats]:= sol_is_sol sol0 solP Kp.
   exact/derivable1_diffP.
@@ -820,7 +878,7 @@ set g := fun i : 'I_2 => if i == 0 then Num.sqrt (1 - p..[2] ^+ 2)
                                    else - (Num.sqrt (1 - p..[2] ^+ 2)).
 rewrite -[p in RHS]sol0.
 apply: (@continuous_finimage_cst (fun t => (sol p t)..[3]) _ g) tge0.
-  move=> s sge0; apply: (@differentiable_continuous [normedModType R of R^o]
+  move=> s sge0; apply: (@differentiable_continuous _ [normedModType R of R^o]
     [normedModType R of R^o]).
   have Kp : K p by apply: subset_limSK_K.
   have [_ /(_ _ sge0) sol_ats]:= sol_is_sol sol0 solP Kp.
@@ -861,10 +919,10 @@ case: (eqVneq (p..[3]) 0) => // p3n0.
 suff : (Fpendulum (sol p 0))..[4] = 0.
   rewrite Fpendulum4E // sol0 => /eqP; rewrite mulrI_eq0; last exact/lregP.
   by move/eqP.
-apply (is_derive_nneg_eq (En0_sol4_eq0 limSKp Epn0) (lerr 0)); last first.
+apply (is_derive_nneg_eq (En0_sol4_eq0 limSKp Epn0) (lexx 0)); last first.
   exact: is_derive_cst.
 have Kp : K p by apply: subset_limSK_K.
-have [_ /(_ _ (lerr 0))] := sol_is_sol sol0 solP Kp.
+have [_ /(_ _ (lexx 0))] := sol_is_sol sol0 solP Kp.
 exact: is_derive_component.
 Qed.
 
@@ -877,27 +935,27 @@ rewrite En0_sol3_eq0 // expr0n /= addr0 -{1}(expr1n [ringType of R] 2).
 move/eqP; rewrite eqf_sqr => /orP [] /eqP // sol2_eqN1 _.
 suff : `|E (sol p t)| < 2 * m%:num * g%:num * l%:num.
   rewrite /E sol1_eq0 // En0_sol4_eq0 // expr0n /= !mulr0 !addr0 mulr0 add0r.
-  rewrite sol2_eqN1 -opprD mulrN absrN mulrC !mulrA mulrAC absRE.
-  by rewrite -(natrD _ 1 1) addn1 ltr_norml ltrr andbF.
-rewrite -[X in _ < X]ger0_norm // absRE -ltr_sqr ?nnegrE // -!normrX.
+  rewrite sol2_eqN1 -opprD mulrN normrN mulrC !mulrA mulrAC.
+  by rewrite -(natrD _ 1 1) addn1 ltr_norml ltxx andbF.
+rewrite -[X in _ < X]ger0_norm // -ltr_sqr ?nnegrE // -!normrX.
 do 2 rewrite ger0_norm ?sqr_ge0 //.
 suff : 2 * (V (sol p t)) / ke%:num < (2 * m%:num * g%:num * l%:num) ^+ 2.
-  apply: ler_lt_trans.
+  apply: le_lt_trans.
   rewrite -mulrA -ler_pdivr_mull // ler_pdivl_mulr // mulrC mulrA.
   by rewrite /V -addrA ler_addl addr_ge0 // pmulr_rge0 // sqr_ge0.
 rewrite ltr_pdivr_mulr // -ltr_pdivl_mull // mulrC [_ * ke%:num]mulrC.
-have /ltr_le_trans : V (sol p t) < B.
+have /lt_le_trans : V (sol p t) < B.
   have [_ Vsolp_s] : K (sol p t) by apply/subset_limSK_K/limSKinvar.
-  exact: ler_lt_trans k0_valid.
+  exact: le_lt_trans k0_valid.
 rewrite /B; apply; apply: ler_pmul => //; apply: ler_pmul => //.
-by rewrite ler_expn2r // ?nnegrE // ler_minl lerr orbC.
+by rewrite ler_expn2r // ?nnegrE // le_minl lexx orbC.
 Qed.
 
 Lemma subset_limSK_homoclinic_orbit : limS sol K `<=` homoclinic_orbit.
 Proof.
 move=> p limSKp; rewrite homoclinicE; case: (eqVneq (E p) 0) => [Ep0|Epn0].
-  have := sol1_eq0 limSKp (lerr _); rewrite sol0 => p10.
-  have := Efctrl_psol0_eq0 limSKp (lerr _).
+  have := sol1_eq0 limSKp (lexx _); rewrite sol0 => p10.
+  have := Efctrl_psol0_eq0 limSKp (lexx _).
   rewrite sol0 Ep0 mulr0 mul0r add0r => /eqP.
   by rewrite mulrI_eq0 => [/eqP|] //; apply/lregP.
 suff Ep0 : E p == 0 by move: Epn0; rewrite Ep0.
@@ -906,7 +964,7 @@ by rewrite !mulr0 !addr0 mulr0.
 Qed.
 
 Lemma cvg_to_homoclinic_orbit p : K p ->
-  sol p @ +oo --> (homoclinic_orbit : set [uniformType of U]).
+  sol p @ +oo --> (homoclinic_orbit : set [the pseudoMetricType _ of U]).
 Proof.
 move=> Kp A [_/posnumP[e] hoe_A]; apply: cvg_to_limS K_compact Kinvar _ Kp _ _.
 exists e%:num => // q [r /subset_limSK_homoclinic_orbit hor re_q].

--- a/pendulum.v
+++ b/pendulum.v
@@ -2,7 +2,8 @@ From mathcomp Require Import ssreflect ssrfun ssrbool ssrnat eqtype choice seq.
 From mathcomp Require Import order.
 From mathcomp Require Import fintype bigop ssralg ssrnum finmap interval ssrint.
 From mathcomp Require Import matrix zmodp.
-From mathcomp Require Import boolp reals Rstruct classical_sets posnum.
+From mathcomp Require Import mathcomp_extra.
+From mathcomp Require Import boolp reals Rstruct classical_sets posnum functions.
 From mathcomp Require Import topology normedtype prodnormedzmodule landau derive.
 Require Import lasalle.
 
@@ -69,7 +70,7 @@ Proof.
 have comp_lin : linear (fun q : 'rV[R]_n.+1 => q..[i] : R^o).
   by move=> ???; rewrite !mxE.
 have comp_cont : continuous (fun q : 'rV[R]_n.+1 => q..[i] : R^o).
-  move=> q A [_/posnumP[e] Ae] /=; apply/nbhs_ballP; exists e%:num => //.
+  move=> q A [_/posnumP[e] Ae] /=; apply/nbhs_ballP; exists e%:num => //=.
   by move=> r /(_ ord0) /(_ (inZp i)) /Ae.
 apply: DiffDef; first exact: (@linear_differentiable _ _ _ (Linear comp_lin)).
 by rewrite (@diff_lin _ _ _ (Linear comp_lin)).
@@ -134,13 +135,18 @@ Proof.
 move=> p clcircp.
 apply/close_eq => //=; first exact: Rhausdorff.
 rewrite (@ball_close _ [normedModType R of R^o]) => e /=.
-have /expr_continuous [_/posnumP[e1] p2e1_sp2he] :=
-  nbhsx_ballx (p..[2] ^+ 2) (e%:num / 2)%:pos.
-have /expr_continuous [_ /posnumP[e2] p3e2_sp3he] :=
-  nbhsx_ballx (p..[3] ^+ 2) (e%:num / 2)%:pos.
+have : nbhs (p ..[ 2] ^+ 2) (ball (p ..[ 2] ^+ 2) ((e%:num / 2)%:pos)%:num).
+  by apply: nbhsx_ballx.
+move=> /expr_continuous [_/posnumP[e1] p2e1_sp2he].
+have : nbhs (p ..[ 3] ^+ 2) (ball (p ..[ 3] ^+ 2) ((e%:num / 2)%:pos)%:num).
+  by apply: nbhsx_ballx.
+move=> /expr_continuous [_ /posnumP[e2] p3e2_sp3he].
 have [q [circq pme12_q]] :
   [set p : U | p..[2] ^+ 2 + p..[3] ^+ 2 = 1] `&`
-  ball p (minr e1%:num e2%:num) !=set0 by apply/clcircp/nbhsx_ballx.
+  ball p (minr e1%:num e2%:num) !=set0.
+   apply/clcircp.
+   rewrite /minr.
+   by case: ifPn => // ?; apply/nbhsx_ballx.
 rewrite -circq.
 rewrite /ball/=.
 rewrite opprD addrACA; apply: le_lt_trans (ler_norm_add _ _) _.
@@ -174,13 +180,11 @@ suff ptoinfty : (fun x => a * (x ^+ 2) - (b * `|x|) - c) @ +oo --> +oo.
 move=> A [M [Mreal sgtMA]]; rewrite !near_simpl; near=> x.
 have lt0x : 0 < x.
   near: x.
-  exists 0; split => //.
-  by rewrite realE lexx.
+  by exists 0; split => //.
 rewrite ger0_norm ?ltW //; apply: sgtMA.
 rewrite ltr_subr_addr expr2 mulrA -mulrBl; apply: le_lt_trans (ler_norm _) _.
 rewrite -[ `|_|%R]sqr_sqrtr // expr2; apply: ltr_pmul; last 1 first.
-- near: x; exists (Num.sqrt `|M + c|); split => //.
-  by rewrite realE sqrtr_ge0.
+- by near: x; exists (Num.sqrt `|M + c|); split => //.
 - exact: sqrtr_ge0.
 - exact: sqrtr_ge0.
 rewrite ltr_subr_addr -ltr_pdivr_mull //; near: x.
@@ -188,9 +192,8 @@ exists (a^-1 * (Num.sqrt `|M + c| + b)); split => //.
 rewrite realM//.
   by rewrite realV// realE (ltW agt0).
 rewrite realD//.
-  by rewrite realE sqrtr_ge0.
 by rewrite realE; apply: le_total.
-Grab Existential Variables. all: end_near. Qed.
+Unshelve. all: by end_near. Qed.
 
 Lemma K_bounded : bounded_set K.
 Proof.
@@ -217,30 +220,28 @@ suff : \forall M \near +oo, forall p, K p -> `| p..[0] | < M /\
 have K1bnd : \forall M \near +oo, forall p, K p -> `| p..[1] | < M.
   near=> M => p [_ Vps].
     suff /lt_trans : `| p..[1] | < Num.sqrt (2 * B / kv%:num).
-    apply; near: M; exists (Num.sqrt (2 * B / kv%:num)); split => //.
-    by rewrite realE sqrtr_ge0.
-  rewrite -sqrtr_sqr ltr_sqrt // mulrAC -ltr_pdivr_mull // invf_div.
+    by apply; near: M; exists (Num.sqrt (2 * B / kv%:num)); split => //.
+  rewrite -sqrtr_sqr ltr_sqrt // mulrAC -ltr_pdivr_mull // invf_div; last first.
+    by rewrite mulr0 /B/=.
   apply: le_lt_trans k0_valid; apply: le_trans Vps.
   by rewrite [V _]addrAC ler_addr addr_ge0 // pmulr_rge0 // sqr_ge0.
 apply: filter_app (K1bnd); near=> M.
 move=> K1ltM p Kp; have [circp Vps] := Kp; split.
   suff /lt_trans : `| p..[0] | < Num.sqrt (2 * B / kx%:num).
-    apply; near: M; exists (Num.sqrt (2 * B / kx%:num)); split => //.
-    by rewrite realE sqrtr_ge0.
-  rewrite -sqrtr_sqr ltr_sqrt // mulrAC -ltr_pdivr_mull // invf_div.
+    by apply; near: M; exists (Num.sqrt (2 * B / kx%:num)); split => //.
+  rewrite -sqrtr_sqr ltr_sqrt // mulrAC -ltr_pdivr_mull // invf_div; last first.
+    by rewrite mulr0 /B.
   apply: le_lt_trans k0_valid; apply: le_trans Vps.
   by rewrite ler_addr addr_ge0 // pmulr_rge0 // sqr_ge0.
 split; first exact: K1ltM; split.
   suff /le_lt_trans : `| p..[2] | <= 1.
     apply.
-    near: M; exists 1; split => //.
-    by rewrite realE ler01.
+    by near: M; exists 1; split => //.
   by rewrite -sqrtr_sqr -sqrtr1 ler_sqrt // -circp ler_addl sqr_ge0.
 split.
   suff /le_lt_trans : `| p..[3] | <= 1.
     apply.
-    near: M; exists 1; split => //.
-    by rewrite realE ler01.
+    by near: M; exists 1; split => //.
   by rewrite -sqrtr_sqr -sqrtr1 ler_sqrt // -circp ler_addr sqr_ge0.
 move: p Kp {circp Vps}; near: M; rewrite /= !near_simpl.
 have [M1 [M1real sgtM1gtK1]] := K1bnd.
@@ -251,7 +252,8 @@ apply: filter_app; near=> M => sEsltM p Kp; have [circp Vps] := Kp.
 apply: sEsltM.
 have : E p < Num.sqrt (2 * B / ke%:num).
   apply: le_lt_trans (ler_norm _) _.
-  rewrite -sqrtr_sqr ltr_sqrt // mulrAC -ltr_pdivr_mull // invf_div.
+  rewrite -sqrtr_sqr ltr_sqrt // mulrAC -ltr_pdivr_mull // invf_div; last first.
+    by rewrite mulr0 /B.
   apply: le_lt_trans k0_valid; apply: le_trans Vps.
   by rewrite -[V _]addrA ler_addl addr_ge0 // pmulr_rge0 // sqr_ge0.
 apply: le_lt_trans; apply: ler_add; last first.
@@ -261,6 +263,7 @@ apply: le_lt_trans; apply: ler_add; last first.
   rewrite -sqrtr_sqr.
   by rewrite -sqrtr1 ler_sqrt // -circp ler_addl sqr_ge0.
 rewrite mulrDr [1 / 2 * _ + _]addrC -addrA [1 / 2 * _]mulrCA mul1r mulrA.
+rewrite /=.
 rewrite (expr2 l%:num) ler_add2l; apply: ler_paddl.
   by rewrite pmulr_rge0 // pmulr_rge0 // sqr_ge0.
 rewrite -mulrN -!mulrA ler_wpmul2l // ler_wpmul2l // !mulrN ler_oppl.
@@ -272,7 +275,7 @@ rewrite !mulrA ler_wpmul2r // ler_pmul //.
   by rewrite ltr_addl.
 have /(le_trans _) : 1 <= `|M1| + 1 by rewrite ler_addr.
 by apply; rewrite -sqrtr_sqr -sqrtr1 ler_sqrt // -circp ler_addl sqr_ge0.
-Unshelve. all: end_near. Grab Existential Variables. all: end_near. Qed.
+Unshelve. all: by end_near. Qed.
 
 Lemma K_compact : compact K.
 Proof. exact: bounded_closed_compact K_bounded K_closed. Qed.
@@ -325,10 +328,20 @@ Lemma eq0_derive1_cst (f : R^o -> R^o) (a b : R) :
   forall t, t \in `[a, b] -> f t = f a.
 Proof.
 move=> f'eq0 t tab; apply/eqP; rewrite eq_le; apply/andP; split.
-  by apply: (@ler0_derive1_nincr _ _ a b) => //; rewrite ?(itvP tab) //;
-    move=> ? /f'eq0 // df; rewrite derive1E derive_val.
-by apply: (@le0r_derive1_ndecr _ _ a b) => //; rewrite ?(itvP tab) //;
-  move=> ? /f'eq0 // df; rewrite derive1E derive_val.
+  apply: (@ler0_derive1_nincr _ _ a b) => //; rewrite ?(itvP tab) //;[
+    by move=> x /subset_itv_oo_cc /f'eq0 // df; rewrite derive1E derive_val..|].
+  apply: continuous_subspaceT => x.
+  rewrite inE/= => /f'eq0.
+  move=> /(@ex_derive _ [the normedModType R of R^o]).
+  move=> /derivable1_diffP /differentiable_continuous.
+  exact.
+apply: (@le0r_derive1_ndecr _ _ a b) => //; rewrite ?(itvP tab) //;[
+  by move=> x /subset_itv_oo_cc /f'eq0 // df; rewrite derive1E derive_val..|].
+apply: continuous_subspaceT => x.
+rewrite inE/= => /f'eq0.
+move=> /(@ex_derive _ [the normedModType R of R^o]).
+move=> /derivable1_diffP /differentiable_continuous.
+exact.
 Qed.
 
 Lemma circ_invar p :
@@ -448,11 +461,14 @@ have Vsol_drvbl t : t \in `]0, (inf A)[ ->
     by rewrite leNgt => /negP; apply; rewrite (itvP t0inf).
   apply: inf_lower_bound => //; apply/andP; split=> //.
   by rewrite (itvP t0inf).
-have : {in `[0, (inf A)], continuous (V \o sol p)}.
+have : {in `[0, (inf A)]%classic, continuous (V \o sol p)}.
   move=> t t0inf; suff /differentiable_continuous :
     differentiable (V \o sol p : R^o -> R^o) t by [].
-  by apply/derivable1_diffP/Vsolp_drvbl; rewrite (itvP t0inf).
-move=> /(MVT infge0 Vsol_drvbl) [t t0inf].
+  apply/derivable1_diffP/Vsolp_drvbl.
+  rewrite inE/= in t0inf.
+  by rewrite (itvP t0inf).
+move/continuous_subspaceT.
+move=> /(MVT_segment infge0)[t t0inf].
 rewrite /comp sol0 subr0 => dVsol.
 have infgt0 : 0 < inf A.
   rewrite lt_def; apply/andP; split=> //.
@@ -481,10 +497,18 @@ apply: le_trans Vp_s; rewrite -{2}[p]sol0.
 have Vsol_deriv : forall s, s \in `[0, t] ->
   is_derive (s : R^o) 1 (V \o sol p : _ -> R^o)
   (- kd%:num * (sol p s)..[1] ^+ 2) by move=> s /andP [/(is_derive_Vsol Kp)].
-apply: (@ler0_derive1_nincr _ (V \o sol p) 0 t);[idtac|idtac|by [] |by [] |by []].
-  by move=> ? /Vsol_deriv.
-move=> s /Vsol_deriv dVsols; rewrite derive1E derive_val.
-by rewrite !mulNr oppr_le0 pmulr_rge0 // sqr_ge0.
+apply: (@ler0_derive1_nincr _ (V \o sol p) 0 t);[| | |by [] |by [] |by []].
+  move=> x /subset_itv_oo_cc /Vsol_deriv.
+  by apply: (@ex_derive _ [the normedModType R of R^o]).
+  move=> x /subset_itv_oo_cc /Vsol_deriv.
+  rewrite derive1E.
+  case => _ ->.
+  by rewrite mulr_le0_ge0// sqr_ge0.
+apply: continuous_subspaceT => x.
+rewrite inE/= => /Vsol_deriv.
+move=> /(@ex_derive _ [the normedModType R of R^o]).
+move=> /derivable1_diffP /differentiable_continuous.
+exact.
 Qed.
 
 Definition homoclinic_orbit : set U := [set p : U | p..[0] = 0 /\ p..[1] = 0 /\
@@ -500,7 +524,8 @@ rewrite predeqE => p; split.
   rewrite !mulr0 !mul0r addr0 add0r mulrA [_ / _ * _]mulrA -mulrN opprB.
   by rewrite [_ * _ * g%:num]mulrAC.
 move=> [p0eq0 [p1eq0 Epeq0]]; split=> //; split=> //.
-apply: subr0_eq; rewrite -Epeq0 /E p1eq0 expr0n /=.
+apply: subr0_eq.
+rewrite -[RHS]Epeq0 /E p1eq0 expr0n /=.
 rewrite !mulr0 !mul0r addr0 add0r [in RHS] mulrA [_ / _ * _ in RHS]mulrA -mulrN.
 by rewrite opprB [_ * _ * g%:num]mulrAC.
 Qed.
@@ -564,8 +589,8 @@ apply: cvg_map_lim => A A0.
 rewrite !near_simpl; near=> h.
 rewrite /= -![(_ - _ : _ -> _) _]/(_ - _) !feg //.
   by rewrite !subrr scaler0; apply: nbhs_singleton.
-by rewrite addr_ge0 // [_%:A]mulr1 ltW //; near: h; exists 1.
-Grab Existential Variables. all: end_near. Qed.
+by rewrite addr_ge0 // [_%:A]mulr1 ltW //; near: h; exists 1 => //=.
+Unshelve. all: by end_near. Qed.
 
 Lemma sol1'_eq0 p t : limS sol K p -> 0 <= t -> (Fpendulum (sol p t))..[1] = 0.
 Proof.
@@ -599,8 +624,8 @@ Lemma Efctrl_psol0_eq0 p t : limS sol K p -> 0 <= t ->
   ke%:num * (E (sol p t)) * (fctrl (sol p t)) + kx%:num * (sol p t)..[0] = 0.
 Proof.
 move=> limSKp tge0.
-have -> :
-  0 = - (kd%:num * (sol p t)..[1] + kv%:num * (Fpendulum (sol p t))..[1]).
+rewrite [RHS](_ : _ =
+    - (kd%:num * (sol p t)..[1] + kv%:num * (Fpendulum (sol p t))..[1])); last first.
   by rewrite sol1'_eq0 // sol1_eq0 // !mulr0 add0r oppr0.
 have [circsolt /le_lt_trans /(_ k0_valid) Vsolts] : K (sol p t).
   by apply: Kinvar tge0; apply: subset_limSK_K.
@@ -647,7 +672,7 @@ Lemma En0_fctrlsol_const p t :
 Proof.
 move=> limSKp Epn0 tge0.
 have := Efctrl_psol0_eq0 limSKp tge0.
-rewrite -(Efctrl_psol0_eq0 limSKp (lexx _)) sol0
+rewrite -[X in _ = X -> _](Efctrl_psol0_eq0 limSKp (lexx _)) sol0
   [E (sol p t)](Esol_const limSKp tge0) (sol0_const limSKp tge0).
 have keEn0 : ke%:num * E p != 0 by rewrite mulrI_eq0 //; apply/lregP.
 move/(canRL (addrK _)); rewrite -addrA subrr addr0 mulrC.
@@ -703,7 +728,9 @@ have imgn0 : nonempty img.
 have infimg : has_inf img.
   by split=> //; exists fl; apply/lbP => ? /andP [/ltW].
 have [] := @IVT _ f _ _ ((fl + inf img) / 2) tge0.
-    by move=> s s0t; apply: fcont; rewrite [_ \in _](itvP s0t).
+  apply: continuous_subspaceT => x.
+  rewrite inE/= in_itv/= => /andP[x0 xt].
+  by apply: fcont => //=.
   apply/andP; split.
     rewrite ler_pdivl_mulr // mulrC mul2r ler_add2l.
     by apply: lb_le_inf imgn0 _; apply/lbP => ? /andP [/ltW].
@@ -850,7 +877,7 @@ have solroot_imf :
   have sol2_root :
     6%:R * g%:num * ((sol p s)..[2] ^+ 2) + C1 * (sol p s)..[2] +
     (- 3%:R * g%:num) = 0.
-    rewrite -sol2_val.
+    rewrite -[RHS]sol2_val.
     (* was ssrring *) admit.
   case/poly2_factor: sol2_root => {sol2_val} [|sol2_val|sol2_val] //.
     by exists (2%:R); rewrite sol2_val.
@@ -969,7 +996,7 @@ Lemma cvg_to_homoclinic_orbit p : K p ->
   sol p @ +oo --> (homoclinic_orbit : set [the pseudoMetricType _ of U]).
 Proof.
 move=> Kp A [_/posnumP[e] hoe_A]; apply: cvg_to_limS K_compact Kinvar _ Kp _ _.
-exists e%:num => // q [r /subset_limSK_homoclinic_orbit hor re_q].
+exists e%:num => //= q [r /subset_limSK_homoclinic_orbit hor re_q].
 by apply: hoe_A; exists r.
 Qed.
 

--- a/pendulum.v
+++ b/pendulum.v
@@ -203,10 +203,6 @@ suff : \forall M \near +oo, forall p, K p -> forall i, `|p ord0 i| < M.
   rewrite /normr/=.
   rewrite mx_normrE.
   apply/bigmax_leP; split => //.
-    near: M.
-    exists 0%R; split.
-      by rewrite realE lexx.
-    by move=> x /ltW.
   move=> i _.
   rewrite ord1.
   apply/ltW.
@@ -330,14 +326,14 @@ Proof.
 move=> f'eq0 t tab; apply/eqP; rewrite eq_le; apply/andP; split.
   apply: (@ler0_derive1_nincr _ _ a b) => //; rewrite ?(itvP tab) //;[
     by move=> x /subset_itv_oo_cc /f'eq0 // df; rewrite derive1E derive_val..|].
-  apply: continuous_subspaceT => x.
+  apply: continuous_in_subspaceT => x.
   rewrite inE/= => /f'eq0.
   move=> /(@ex_derive _ [the normedModType R of R^o]).
   move=> /derivable1_diffP /differentiable_continuous.
   exact.
 apply: (@le0r_derive1_ndecr _ _ a b) => //; rewrite ?(itvP tab) //;[
   by move=> x /subset_itv_oo_cc /f'eq0 // df; rewrite derive1E derive_val..|].
-apply: continuous_subspaceT => x.
+apply: continuous_in_subspaceT => x.
 rewrite inE/= => /f'eq0.
 move=> /(@ex_derive _ [the normedModType R of R^o]).
 move=> /derivable1_diffP /differentiable_continuous.
@@ -467,7 +463,7 @@ have : {in `[0, (inf A)]%classic, continuous (V \o sol p)}.
   apply/derivable1_diffP/Vsolp_drvbl.
   rewrite inE/= in t0inf.
   by rewrite (itvP t0inf).
-move/continuous_subspaceT.
+move/continuous_in_subspaceT.
 move=> /(MVT_segment infge0)[t t0inf].
 rewrite /comp sol0 subr0 => dVsol.
 have infgt0 : 0 < inf A.
@@ -504,7 +500,7 @@ apply: (@ler0_derive1_nincr _ (V \o sol p) 0 t);[| | |by [] |by [] |by []].
   rewrite derive1E.
   case => _ ->.
   by rewrite mulr_le0_ge0// sqr_ge0.
-apply: continuous_subspaceT => x.
+apply: continuous_in_subspaceT => x.
 rewrite inE/= => /Vsol_deriv.
 move=> /(@ex_derive _ [the normedModType R of R^o]).
 move=> /derivable1_diffP /differentiable_continuous.
@@ -583,7 +579,7 @@ move=> feg tge0 df dg.
 have /@derive_val <- := df; have /@derive_val <- := dg.
 apply: subr0_eq; rewrite -deriveB // /derive cvg_at_rightE; last first.
   by rewrite -[cvg _]/(derivable _ _ _).
-apply: cvg_map_lim => A A0.
+apply: cvg_lim => A A0.
   rewrite -closeEnbhs.
   by rewrite norm_closeE.
 rewrite !near_simpl; near=> h.
@@ -728,7 +724,7 @@ have imgn0 : nonempty img.
 have infimg : has_inf img.
   by split=> //; exists fl; apply/lbP => ? /andP [/ltW].
 have [] := @IVT _ f _ _ ((fl + inf img) / 2) tge0.
-  apply: continuous_subspaceT => x.
+  apply: continuous_in_subspaceT => x.
   rewrite inE/= in_itv/= => /andP[x0 xt].
   by apply: fcont => //=.
   apply/andP; split.

--- a/pendulum.v
+++ b/pendulum.v
@@ -3,7 +3,7 @@ From mathcomp Require Import order.
 From mathcomp Require Import fintype bigop ssralg ssrnum finmap interval ssrint.
 From mathcomp Require Import matrix zmodp.
 From mathcomp Require Import mathcomp_extra.
-From mathcomp Require Import boolp reals Rstruct classical_sets posnum functions.
+From mathcomp Require Import boolp reals Rstruct classical_sets signed functions.
 From mathcomp Require Import topology normedtype prodnormedzmodule landau derive.
 Require Import lasalle.
 
@@ -127,7 +127,7 @@ Proof.
 move=> x; suff : differentiable (fun y : R^o => y ^+ n.+1) x.
   by apply: differentiable_continuous.
 suff -> : (fun y => y ^+ n.+1) = ((id : R^o -> R^o) ^+ n.+1) by [].
-by rewrite exprfunE.
+by rewrite exprfctE.
 Qed.
 
 Lemma circle_closed : closed [set p : U | p..[2] ^+ 2 + p..[3] ^+ 2 = 1].
@@ -202,7 +202,7 @@ suff : \forall M \near +oo, forall p, K p -> forall i, `|p ord0 i| < M.
   move=> Kbnd /= p /Kbnd ltpM.
   rewrite /normr/=.
   rewrite mx_normrE.
-  apply/bigmax_lerP; split => //.
+  apply/bigmax_leP; split => //.
     near: M.
     exists 0%R; split.
       by rewrite realE lexx.

--- a/pendulum.v
+++ b/pendulum.v
@@ -1,4 +1,4 @@
-Require Import Reals ssrring.
+Require Import Reals.
 From mathcomp Require Import ssreflect ssrfun ssrbool ssrnat eqtype choice seq.
 From mathcomp Require Import fintype bigop ssralg ssrnum finmap interval ssrint.
 From mathcomp Require Import matrix zmodp.
@@ -335,8 +335,9 @@ apply: (canLR (subrK _)); rewrite -mulrBl [_ * (_ + y)]mulrDr opprD addrA.
 rewrite [_ * (_ - _ * y)]mulrDr addrA -[- (_ * y)]mulNr [_ * (_ * y)]mulrA.
 rewrite [_ + _ * y + _]addrAC; apply: (canLR (subrK _)); rewrite -mulrBl.
 rewrite mulrN opprK mulrACA [_ ^+2 / _]mulrAC mulfVK //.
-by rewrite [_ / _]mulrC ![_^-1 * _]mulrA [_^-1 * _ * _]mulrC mulVKf //; ssring.
-Qed.
+rewrite [_ / _]mulrC ![_^-1 * _]mulrA [_^-1 * _ * _]mulrC mulVKf //.
+(* was ssring *)admit.
+Admitted.
 
 Lemma is_deriv_Vsol p t :
   K p -> 0 <= t -> V (sol p t) < B ->
@@ -359,8 +360,8 @@ apply: (canLR (mulfK _)) => //; rewrite [kv%:num * _]mulrDr addrA addrAC.
 apply: (canLR (subrK _)); rewrite mulrAC -mulrDl /fctrl [LHS]mulrA.
 have circp : (sol p t)..[2] ^+ 2 + (sol p t)..[3] ^+ 2 = 1 by apply: circ_invar.
 have fctrl_def := fctrl_wdef circp Vsolpt_s; apply: (canLR (mulfK _)) => //.
-by ssring.
-Qed.
+(*by ssring.*) admit.
+Admitted.
 
 Lemma defset_invar p : K p -> forall t, 0 <= t ->
   (sol p t)..[2] ^+ 2 + (sol p t)..[3] ^+ 2 = 1 /\ V (sol p t) < B.
@@ -560,8 +561,10 @@ apply: (canLR (mulfK _)) => //; rewrite [RHS]mulrDl; apply: (canRL (subrK _)).
 rewrite opprD [RHS]mulrDl [RHS]addrC; apply/(canRL (subrK _))/Logic.eq_sym.
 rewrite mulrC -mulNr mulrA mulrA; apply: (canLR (mulfK _)) => //.
 rewrite mulrDr [LHS]mulrDr addrC; apply: (canLR (subrK _)).
-by rewrite [LHS]mulrA [LHS]mulrA; apply: (canLR (mulfK _)) => //; ssring.
-Qed.
+rewrite [LHS]mulrA [LHS]mulrA; apply: (canLR (mulfK _)) => //.
+(* was ssring. *)
+admit.
+Admitted.
 
 Lemma div_fctrl_mP p t : limS sol K p -> 0 <= t ->
   (sol p t)..[3] * (g%:num * (sol p t)..[2] - l%:num * (sol p t)..[4] ^+ 2) =
@@ -583,8 +586,10 @@ apply: (canLR (mulfK _)); last apply/Logic.eq_sym.
   by apply: lt0r_neq0; rewrite pmulr_rgt0 // Mp_ms_gt0.
 rewrite mulrCA mulrA mulrA [l%:num * _ in LHS]mulrC mulrVK ?unitfE //.
 have [] : K (sol p t) by apply/subset_limSK_K/limSKinvar.
-by rewrite addrC => /(canRL (addrK _)) -> _; ssring.
-Qed.
+rewrite addrC => /(canRL (addrK _)) -> _.
+(* ssrring *)
+admit.
+Admitted.
 
 Lemma En0_fctrlsol_const p t :
   limS sol K p -> E p != 0 -> 0 <= t -> fctrl (sol p t) = fctrl p.
@@ -735,14 +740,16 @@ have sol32_val : forall s, 0 <= s ->
   rewrite expr0n /= !mulr0 !mul0r add0r addr0 mulrDr mulrA [1 / _]mulrC.
   rewrite mulVKr ?unitfE // mul1r mulrBr addrC; apply: (canLR (subrK _)).
   rewrite -mulNr mulrDr addrC; apply: (canLR (subrK _)).
-  by rewrite mulrA; apply: (canLR (mulfK _)) => //; ssring.
+  rewrite mulrA; apply: (canLR (mulfK _)) => //.
+  (* was ssrring *) admit.
 have sol423_val s : 0 <= s ->
   (sol p s)..[4] * (3%:R * g%:num * ((sol p s)..[2] ^+ 2 -
   (sol p s)..[3] ^+ 2) + C1 * (sol p s)..[2]) = 0.
   move=> sge0; apply (is_derive_nneg_eq sol32_val sge0); last first.
     exact: is_derive_cst.
   have [_ /(_ _ sge0) sol_ats] := sol_is_sol sol0 solP Kp; apply: is_derive_eq.
-  by rewrite !mxE /=; ssring.
+  rewrite !mxE /=.
+  (* was ssrring *) admit.
 have sol432_val' s : 0 <= s ->
   (sol p s)..[3] * (g%:num / l%:num * (3%:R * g%:num * ((sol p s)..[2] ^+ 2 -
     (sol p s)..[3] ^+ 2) + C1 * (sol p s)..[2]) -
@@ -755,7 +762,8 @@ have sol432_val' s : 0 <= s ->
   rewrite [in RHS]mulrDl; apply: (canRL (subrK _)).
   rewrite [(sol p s)..[3] * _]mulrDr [in RHS]mulrDl; apply: (canRL (subrK _)).
   rewrite [_ / _ * _]mulrC [in RHS]mulrA [in RHS]mulrA mulrVK ?unitfE //.
-  by ssring.
+  (* was ssring *)
+  admit.
 set x1 := (- C1 + Num.sqrt (C1 ^+ 2 - 4%:R * (6%:R * g%:num) *
   (- 3%:R * g%:num))) / (2 * (6%:R * g%:num)).
 set x2 := (- C1 - Num.sqrt (C1 ^+ 2 - 4%:R * (6%:R * g%:num) *
@@ -782,7 +790,8 @@ have solroot_imf :
   have sol2_root :
     6%:R * g%:num * ((sol p s)..[2] ^+ 2) + C1 * (sol p s)..[2] +
     (- 3%:R * g%:num) = 0.
-    by rewrite -sol2_val; ssring.
+    rewrite -sol2_val.
+    (* was ssrring *) admit.
   case/poly2_factor: sol2_root => {sol2_val} [|sol2_val|sol2_val] //.
     by exists (2%:R); rewrite sol2_val.
   by exists (3%:R); rewrite sol2_val.
@@ -797,7 +806,7 @@ case: (eqVneq ((sol p s)..[3]) 0) => [sol3e0|sol3ne0].
   by exists 0.
 move=> /eqP; rewrite mulrI_eq0; last exact/lregP.
 by rewrite mulrI_eq0=> [/eqP|] //; apply/lregP.
-Qed.
+Admitted.
 
 Lemma En0_sol3_const p :
   limS sol K p -> E p != 0 -> forall t, 0 <= t -> (sol p t)..[3] = p..[3].

--- a/pendulum.v
+++ b/pendulum.v
@@ -33,7 +33,7 @@ Parameter m M l g : {posnum R}.
 
 Variable ke kv kx kd : {posnum R}.
 
-Let U := 'rV[R]_5.
+Notation U := 'rV[R]_5.
 
 (* p = (x, x', cos theta, sin theta, theta') *)
 Definition E (p : U) :=
@@ -290,7 +290,7 @@ rewrite ltr_pdivrMr // mulrC -ltr_pdivlMr // (lt_le_trans Vp_s) //.
 rewrite -mulrA mulrCA mulrA; apply: ler_pM => //; apply: ler_pM => //.
 apply/ge0_expr_ndecr/andP; split; last first.
   by rewrite ge_min/= lexx.
-by rewrite le_minr; apply/andP; split.
+by rewrite le_min; apply/andP; split.
 Qed.
 
 Lemma fctrl_wdef (p : U) : (p..[2] ^+ 2) + (p..[3] ^+ 2) = 1 -> V p < B ->
@@ -447,7 +447,7 @@ have Vsolpinf_geB : B <= V (sol p (inf A)).
     by rewrite leNgt => /negP; apply; rewrite ltrDl.
   apply: lb_le_inf An0 _; apply/lbP => s /andP [sge0 Vsolps_geB].
   rewrite leNgt; apply/negP => ltsinfphe; have leinfs : inf A <= s.
-    apply: inf_lb => //.
+    apply: inf_lbound => //.
       by case: infA.
     by rewrite /A/= sge0 Vsolps_geB.
   suff /infe_Vsolp : ball (inf A) e%:num s.
@@ -461,7 +461,7 @@ have Vsol_drvbl t : t \in `]0, (inf A)[ ->
   move=> t0inf; apply: is_deriv_Vsol => //; first by rewrite (itvP t0inf).
   rewrite ltNge; apply/negP => Vsolpt_geB; suff : inf A <= t.
     by rewrite leNgt => /negP; apply; rewrite (itvP t0inf).
-  apply: inf_lb => //.
+  apply: inf_lbound => //.
     by case: infA.
   apply/andP; split=> //.
   by rewrite (itvP t0inf).
@@ -694,7 +694,7 @@ have Amin : \big[minr/t]_(s <- enum_fset A) s \in A.
   by apply: ihl => r lr; apply: inA; rewrite inE orbC lr.
 suff -> : inf [set t | t \in A] = \big[minr/t]_(s <- enum_fset A) s by [].
 apply/eqP; rewrite eq_le; apply/andP; split.
-  apply: inf_lb => //.
+  apply: inf_lbound => //.
   by case: infA.
 apply: lb_le_inf; first by have [] := infA.
 apply/lbP => s As; have : s \in enum_fset A by [].
@@ -739,12 +739,12 @@ have [] := @IVT _ f _ _ ((fl + inf img) / 2) tge0.
     rewrite ler_pdivlMr // mulrC mul2r lerD2l.
     by apply: lb_le_inf imgn0 _; apply/lbP => ? /andP [/ltW].
   rewrite ler_pdivrMr // mulrC mul2r lerD //; first exact: ltW.
-  apply: inf_lb => //.
+  apply: inf_lbound => //.
     by case: infimg.
   by apply/andP; split=> //; apply/asboolP.
 move=> s s0t fsemid; suff ltfl_inf : fl < inf img.
   have : inf img <= (fl + inf img) / 2.
-    apply: inf_lb.
+    apply: inf_lbound.
       by case: infimg.
     apply/andP; split; last first.
       have /finim_f [i] : 0 <= s by rewrite (itvP s0t).
@@ -902,7 +902,7 @@ have /sol432_val' := sge0.
 rewrite sol4e0 expr0n /= mul0r subr0.
 case: (eqVneq ((sol p s)..[3]) 0) => [sol3e0|sol3ne0].
   move=> _; move: circsol; rewrite sol3e0 expr0n /= addr0.
-  rewrite -(expr1n [ringType of R] 2) => /eqP; rewrite eqf_sqr=> /orP [] /eqP->.
+  rewrite -(expr1n R 2) => /eqP; rewrite eqf_sqr=> /orP [] /eqP->.
     by exists 1.
   by exists 0.
 move=> /eqP; rewrite mulrI_eq0; last exact/lregP.
@@ -973,7 +973,7 @@ Lemma En0_sol2_eq1 p t :
 Proof.
 move=> limSKp Epn0 tge0.
 have [] : K (sol p t) by apply/subset_limSK_K/limSKinvar.
-rewrite En0_sol3_eq0 // expr0n /= addr0 -{1}(expr1n [ringType of R] 2).
+rewrite En0_sol3_eq0 // expr0n /= addr0 -{1}(expr1n R 2).
 move/eqP; rewrite eqf_sqr => /orP [] /eqP // sol2_eqN1 _.
 suff : `|E (sol p t)| < 2 * m%:num * g%:num * l%:num.
   rewrite /E sol1_eq0 // En0_sol4_eq0 // expr0n /= !mulr0 !addr0 mulr0 add0r.

--- a/pendulum.v
+++ b/pendulum.v
@@ -134,7 +134,7 @@ rewrite -circq.
 rewrite /ball/=.
 rewrite opprD addrACA; apply: le_lt_trans (ler_norm_add _ _) _.
 by rewrite (splitr e%:num) ltr_add //; [apply/p2e1_sp2he|apply/p3e2_sp3he];
-  apply: ball_ler (pme12_q _ _); rewrite le_minl lexx // orbC.
+  apply: le_ball (pme12_q _ _); rewrite le_minl lexx // orbC.
 Qed.
 
 Lemma preimV_lek0_closed : closed (V @^-1` (<= k0 : _ -> _)).
@@ -335,7 +335,8 @@ Proof.
 move=> Kp /= t tge0; have [circp _] := Kp; rewrite -circp -[in RHS](sol0 p).
 pose f s := (sol p s)..[2] ^+ 2 + (sol p s)..[3] ^+ 2; rewrite -!/(f _).
 (* BUG in unification *)
-apply (@eq0_derive1_cst (f : R^o -> R^o) 0 t); last by rewrite inE/= lexx tge0.
+apply (@eq0_derive1_cst (f : R^o -> R^o) 0 t); last first.
+  by rewrite in_itv/= lexx tge0.
 move=> s s0t; have sge0 : s >= 0 by rewrite (itvP s0t).
 have [_ /(_ _ sge0) dsol] := sol_is_sol sol0 solP Kp.
 apply: is_derive_eq.
@@ -431,7 +432,7 @@ have Vsolpinf_geB : B <= V (sol p (inf A)).
   apply: lb_le_inf An0 _; apply/lbP => s /andP [sge0 Vsolps_geB].
   rewrite leNgt; apply/negP => ltsinfphe; have leinfs : inf A <= s.
     apply: inf_lower_bound => //.
-    by rewrite /A sge0 Vsolps_geB.
+    by rewrite /A/= sge0 Vsolps_geB.
   suff /infe_Vsolp : ball (inf A) e%:num s.
     rewrite /ball/= distrC => /(le_lt_trans (ler_norm _)).
     by rewrite ltNge => /negP; apply; rewrite ler_sub.
@@ -557,7 +558,7 @@ have /@derive_val <- := df; have /@derive_val <- := dg.
 apply: subr0_eq; rewrite -deriveB // /derive cvg_at_rightE; last first.
   by rewrite -[cvg _]/(derivable _ _ _).
 apply: cvg_map_lim => A A0.
-  rewrite -close_cluster.
+  rewrite -closeEnbhs.
   by rewrite norm_closeE.
 rewrite !near_simpl; near=> h.
 rewrite /= -![(_ - _ : _ -> _) _]/(_ - _) !feg //.
@@ -577,7 +578,7 @@ Lemma sol0_const p t : limS sol K p -> 0 <= t -> (sol p t)..[0] = p..[0].
 Proof.
 move=> limSKp tge0; rewrite -[p in RHS]sol0.
 apply (@eq0_derive1_cst (fun s => (sol p s)..[0]) 0 t); last first.
-  by rewrite inE/= lexx tge0.
+  by rewrite in_itv/= lexx tge0.
 move=> s /andP [sge0 _]; have /subset_limSK_K Kp := limSKp.
 have [_ /(_ _ sge0) /(is_derive_component 0) dsol0] := sol_is_sol sol0 solP Kp.
 by apply: DeriveDef => //; rewrite derive_val mxE /= sol1_eq0.
@@ -587,7 +588,7 @@ Lemma Esol_const p t : limS sol K p -> 0 <= t -> (E \o sol p) t = E p.
 Proof.
 move=> limSKp tge0; rewrite -[p in RHS]sol0.
 apply (@eq0_derive1_cst (E \o sol p) 0 t); last first.
-  by rewrite inE/= lexx tge0.
+  by rewrite in_itv/= lexx tge0.
 move=> s /andP [sge0 _]; have /subset_limSK_K Kp := limSKp.
 have dEsol := is_derive_Esol Kp sge0; apply: DeriveDef => //.
 by rewrite derive_val sol1_eq0 // mul0r.
@@ -697,7 +698,7 @@ have imgfr : (g @` setT) fr.
   by have /finim_f [i] := lexx (0 : R); exists i.
 have imgn0 : nonempty img.
   exists fr.
-  by rewrite /img ltflr andTb; apply/asboolP.
+  by rewrite /img/= ltflr andTb; apply/asboolP.
 have infimg : has_inf img.
   by split=> //; exists fl; apply/lbP => ? /andP [/ltW].
 have [] := @IVT _ f _ _ ((fl + inf img) / 2) tge0.

--- a/pendulum.v
+++ b/pendulum.v
@@ -2,7 +2,7 @@ From HB Require Import structures.
 From mathcomp Require Import ssreflect ssrfun ssrbool ssrnat eqtype choice seq.
 From mathcomp Require Import order.
 From mathcomp Require Import fintype bigop ssralg ssrnum finmap interval ssrint.
-From mathcomp Require Import matrix zmodp.
+From mathcomp Require Import matrix zmodp ring.
 From mathcomp Require Import mathcomp_extra.
 From mathcomp Require Import boolp reals Rstruct classical_sets signed functions.
 From mathcomp Require Import topology normedtype prodnormedzmodule landau derive.
@@ -151,7 +151,7 @@ rewrite -circq.
 rewrite /ball/=.
 rewrite opprD addrACA; apply: le_lt_trans (ler_normD _ _) _.
 by rewrite (splitr e%:num) ltrD //; [apply/p2e1_sp2he|apply/p3e2_sp3he];
-  apply: le_ball (pme12_q _ _); rewrite le_minl lexx // orbC.
+  apply: le_ball (pme12_q _ _); rewrite ge_min lexx // orbC.
 Qed.
 
 Lemma preimV_lek0_closed : closed (V @^-1` (<= k0 : _ -> _)).
@@ -289,7 +289,7 @@ suff : 2 * (V p) / ke%:num < (kv%:num / (ke%:num * (M%:num + m%:num))) ^+ 2.
 rewrite ltr_pdivrMr // mulrC -ltr_pdivlMr // (lt_le_trans Vp_s) //.
 rewrite -mulrA mulrCA mulrA; apply: ler_pM => //; apply: ler_pM => //.
 apply/ge0_expr_ndecr/andP; split; last first.
-  by rewrite le_minl/= lexx.
+  by rewrite ge_min/= lexx.
 by rewrite le_minr; apply/andP; split.
 Qed.
 
@@ -392,8 +392,8 @@ rewrite [_ * (_ - _ * y)]mulrDr addrA -[- (_ * y)]mulNr [_ * (_ * y)]mulrA.
 rewrite [_ + _ * y + _]addrAC; apply: (canLR (subrK _)); rewrite -mulrBl.
 rewrite [in RHS]mulrN opprK mulrACA [_ ^+2 / _]mulrAC mulfVK //.
 rewrite [_ / _]mulrC ![_^-1 * _]mulrA [_^-1 * _ * _]mulrC mulVKf //.
-(* was ssring *)admit.
-Admitted.
+ring.
+Qed.
 
 Lemma is_deriv_Vsol p t :
   K p -> 0 <= t -> V (sol p t) < B ->
@@ -416,8 +416,8 @@ apply: (canLR (mulfK _)) => //; rewrite [kv%:num * _]mulrDr addrA addrAC.
 apply: (canLR (subrK _)); rewrite mulrAC -mulrDl /fctrl [LHS]mulrA.
 have circp : (sol p t)..[2] ^+ 2 + (sol p t)..[3] ^+ 2 = 1 by apply: circ_invar.
 have fctrl_def := fctrl_wdef circp Vsolpt_s; apply: (canLR (mulfK _)) => //.
-(*by ssring.*) admit.
-Admitted.
+ring.
+Qed.
 
 Lemma defset_invar p : K p -> forall t, 0 <= t ->
   (sol p t)..[2] ^+ 2 + (sol p t)..[3] ^+ 2 = 1 /\ V (sol p t) < B.
@@ -447,7 +447,8 @@ have Vsolpinf_geB : B <= V (sol p (inf A)).
     by rewrite leNgt => /negP; apply; rewrite ltrDl.
   apply: lb_le_inf An0 _; apply/lbP => s /andP [sge0 Vsolps_geB].
   rewrite leNgt; apply/negP => ltsinfphe; have leinfs : inf A <= s.
-    apply: inf_lower_bound => //.
+    apply: inf_lb => //.
+      by case: infA.
     by rewrite /A/= sge0 Vsolps_geB.
   suff /infe_Vsolp : ball (inf A) e%:num s.
     rewrite /ball/= distrC => /(le_lt_trans (ler_norm _)).
@@ -460,7 +461,9 @@ have Vsol_drvbl t : t \in `]0, (inf A)[ ->
   move=> t0inf; apply: is_deriv_Vsol => //; first by rewrite (itvP t0inf).
   rewrite ltNge; apply/negP => Vsolpt_geB; suff : inf A <= t.
     by rewrite leNgt => /negP; apply; rewrite (itvP t0inf).
-  apply: inf_lower_bound => //; apply/andP; split=> //.
+  apply: inf_lb => //.
+    by case: infA.
+  apply/andP; split=> //.
   by rewrite (itvP t0inf).
 have : {in `[0, (inf A)]%classic, continuous (V \o sol p)}.
   move=> t t0inf; suff /differentiable_continuous :
@@ -639,9 +642,8 @@ rewrite opprD [RHS]mulrDl [RHS]addrC; apply/(canRL (subrK _))/Logic.eq_sym.
 rewrite mulrC -mulNr mulrA mulrA; apply: (canLR (mulfK _)) => //.
 rewrite [RHS]mulrDr [LHS]mulrDr addrC; apply: (canLR (subrK _)).
 rewrite mulrA -[in X in X / _]mulrA; apply: (canLR (mulfK _)) => //.
-(* was ssring. *)
-admit.
-Admitted.
+ring.
+Qed.
 
 Lemma div_fctrl_mP p t : limS sol K p -> 0 <= t ->
   (sol p t)..[3] * (g%:num * (sol p t)..[2] - l%:num * (sol p t)..[4] ^+ 2) =
@@ -664,9 +666,8 @@ apply: (canLR (mulfK _)); last apply/Logic.eq_sym.
 rewrite mulrCA mulrA mulrA [l%:num * _ in LHS]mulrC mulrVK ?unitfE //.
 have [] : K (sol p t) by apply/subset_limSK_K/limSKinvar.
 rewrite addrC => /(canRL (addrK _)) -> _.
-(* ssrring *)
-admit.
-Admitted.
+ring.
+Qed.
 
 Lemma En0_fctrlsol_const p t :
   limS sol K p -> E p != 0 -> 0 <= t -> fctrl (sol p t) = fctrl p.
@@ -692,12 +693,14 @@ have Amin : \big[minr/t]_(s <- enum_fset A) s \in A.
     by apply: inA; rewrite mem_head.
   by apply: ihl => r lr; apply: inA; rewrite inE orbC lr.
 suff -> : inf [set t | t \in A] = \big[minr/t]_(s <- enum_fset A) s by [].
-apply/eqP; rewrite eq_le; apply/andP; split; first exact: inf_lower_bound Amin.
+apply/eqP; rewrite eq_le; apply/andP; split.
+  apply: inf_lb => //.
+  by case: infA.
 apply: lb_le_inf; first by have [] := infA.
 apply/lbP => s As; have : s \in enum_fset A by [].
 elim: (enum_fset A) => // r l ihl; rewrite inE => /orP [/eqP <-|].
-  by rewrite big_cons le_minl lexx.
-by rewrite big_cons le_minl orbC => /ihl ->.
+  by rewrite big_cons ge_min lexx.
+by rewrite big_cons ge_min orbC => /ihl ->.
 Qed.
 
 Lemma continuous_finimage_cst (f : R -> R) n (g : 'I_n -> R) :
@@ -736,10 +739,14 @@ have [] := @IVT _ f _ _ ((fl + inf img) / 2) tge0.
     rewrite ler_pdivlMr // mulrC mul2r lerD2l.
     by apply: lb_le_inf imgn0 _; apply/lbP => ? /andP [/ltW].
   rewrite ler_pdivrMr // mulrC mul2r lerD //; first exact: ltW.
-  by apply: inf_lower_bound infimg _ _; apply/andP; split=> //; apply/asboolP.
+  apply: inf_lb => //.
+    by case: infimg.
+  by apply/andP; split=> //; apply/asboolP.
 move=> s s0t fsemid; suff ltfl_inf : fl < inf img.
   have : inf img <= (fl + inf img) / 2.
-    apply: inf_lower_bound (infimg) _ _; apply/andP; split; last first.
+    apply: inf_lb.
+      by case: infimg.
+    apply/andP; split; last first.
       have /finim_f [i] : 0 <= s by rewrite (itvP s0t).
       by rewrite fsemid => midegi; apply/asboolP; exists i.
     by rewrite ltr_pdivlMr // mulrC mul2r ltrD2l.
@@ -836,7 +843,7 @@ have sol32_val : forall s, 0 <= s ->
   rewrite mulVKr ?unitfE // mul1r mulrBr addrC; apply: (canLR (subrK _)).
   rewrite -mulNr mulrDr addrC; apply: (canLR (subrK _)).
   rewrite mulrA; apply: (canLR (mulfK _)) => //.
-  (* was ssrring *) admit.
+  ring.
 have sol423_val s : 0 <= s ->
   (sol p s)..[4] * (3%:R * g%:num * ((sol p s)..[2] ^+ 2 -
   (sol p s)..[3] ^+ 2) + C1 * (sol p s)..[2]) = 0.
@@ -844,7 +851,8 @@ have sol423_val s : 0 <= s ->
     exact: is_derive_cst.
   have [_ /(_ _ sge0) sol_ats] := sol_is_sol sol0 solP Kp; apply: is_derive_eq.
   rewrite !mxE /=.
-  (* was ssrring *) admit.
+  rewrite /GRing.scale/=.
+  ring.
 have sol432_val' s : 0 <= s ->
   (sol p s)..[3] * (g%:num / l%:num * (3%:R * g%:num * ((sol p s)..[2] ^+ 2 -
     (sol p s)..[3] ^+ 2) + C1 * (sol p s)..[2]) -
@@ -857,8 +865,7 @@ have sol432_val' s : 0 <= s ->
   rewrite [in RHS]mulrDl; apply: (canRL (subrK _)).
   rewrite [(sol p s)..[3] * _]mulrDr [in RHS]mulrDl; apply: (canRL (subrK _)).
   rewrite [_ / _ * _]mulrC [in RHS]mulrA [in RHS]mulrA mulrVK ?unitfE //.
-  (* was ssring *)
-  admit.
+  ring.
 set x1 := (- C1 + Num.sqrt (C1 ^+ 2 - 4%:R * (6%:R * g%:num) *
   (- 3%:R * g%:num))) / (2 * (6%:R * g%:num)).
 set x2 := (- C1 - Num.sqrt (C1 ^+ 2 - 4%:R * (6%:R * g%:num) *
@@ -885,7 +892,7 @@ have solroot_imf :
     6%:R * g%:num * ((sol p s)..[2] ^+ 2) + C1 * (sol p s)..[2] +
     (- 3%:R * g%:num) = 0.
     rewrite -[RHS]sol2_val.
-    (* was ssrring *) admit.
+    ring.
   case/poly2_factor: sol2_root => {sol2_val} [|sol2_val|sol2_val] //.
     by exists (2%:R); rewrite sol2_val.
   by exists (3%:R); rewrite sol2_val.
@@ -900,7 +907,7 @@ case: (eqVneq ((sol p s)..[3]) 0) => [sol3e0|sol3ne0].
   by exists 0.
 move=> /eqP; rewrite mulrI_eq0; last exact/lregP.
 by rewrite mulrI_eq0=> [/eqP|] //; apply/lregP.
-Admitted.
+Qed.
 
 Lemma En0_sol3_const p :
   limS sol K p -> E p != 0 -> forall t, 0 <= t -> (sol p t)..[3] = p..[3].
@@ -983,7 +990,7 @@ have /lt_le_trans : V (sol p t) < B.
   have [_ Vsolp_s] : K (sol p t) by apply/subset_limSK_K/limSKinvar.
   exact: le_lt_trans k0_valid.
 rewrite /B; apply; apply: ler_pM => //; apply: ler_pM => //.
-by rewrite lerXn2r // ?nnegrE // le_minl lexx orbC.
+by rewrite lerXn2r // ?nnegrE // ge_min lexx orbC.
 Qed.
 
 Lemma subset_limSK_homoclinic_orbit : limS sol K `<=` homoclinic_orbit.

--- a/pendulum.v
+++ b/pendulum.v
@@ -1,4 +1,3 @@
-Require Import Reals.
 From mathcomp Require Import ssreflect ssrfun ssrbool ssrnat eqtype choice seq.
 From mathcomp Require Import order.
 From mathcomp Require Import fintype bigop ssralg ssrnum finmap interval ssrint.
@@ -12,13 +11,25 @@ Unset Strict Implicit.
 Unset Printing Implicit Defensive.
 Import GRing.Theory Num.Def Num.Theory Order.POrderTheory Order.TotalTheory.
 
+Import numFieldTopology.Exports.
+
 Local Open Scope classical_set_scope.
 Local Open Scope ring_scope.
 
 Notation "p ..[ i ]" := (p 0 (inZp i)) (at level 10).
 
-Section System.
+Lemma ge0_expr_ndecr (R : realDomainType) n (x y : R) :
+  0 <= x <= y -> x ^+ n <= y ^+ n.
+Proof.
+move=> /andP [xge0 yge0]; elim: n => [|n ihn]; first by rewrite !expr0.
+by rewrite !exprS ler_pmul // exprn_ge0.
+Qed.
 
+Lemma mul2r (R : ringType) (x : R) : 2 * x = x + x.
+Proof. by rewrite -mulr2n mulr_natl. Qed.
+
+Section System.
+Context {R : realType}.
 Parameter m M l g : {posnum R}.
 
 Variable ke kv kx kd : {posnum R}.
@@ -184,11 +195,11 @@ Grab Existential Variables. all: end_near. Qed.
 Lemma K_bounded : bounded_set K.
 Proof.
 suff : \forall M \near +oo, forall p, K p -> forall i, `|p ord0 i| < M.
-  rewrite /bounded; apply: filter_app; near=> M.
+  rewrite /bounded_set; apply: filter_app; near=> M.
   move=> Kbnd /= p /Kbnd ltpM.
   rewrite /normr/=.
   rewrite mx_normrE.
-  apply/BigmaxBigminr.bigmaxr_lerP; split => //.
+  apply/bigmax_lerP; split => //.
     near: M.
     exists 0%R; split.
       by rewrite realE lexx.
@@ -245,11 +256,9 @@ have : E p < Num.sqrt (2 * B / ke%:num).
   by rewrite -[V _]addrA ler_addl addr_ge0 // pmulr_rge0 // sqr_ge0.
 apply: le_lt_trans; apply: ler_add; last first.
   rewrite -mulrN opprD ler_wpmul2l //.
-    by rewrite !RmultE.
   rewrite ler_add2r ler_oppl.
   rewrite ler_paddl // (le_trans (ler_norm _)) // normrN.
   rewrite -sqrtr_sqr.
-  rewrite (_ : 1%coqR = 1)//.
   by rewrite -sqrtr1 ler_sqrt // -circp ler_addl sqr_ge0.
 rewrite mulrDr [1 / 2 * _ + _]addrC -addrA [1 / 2 * _]mulrCA mul1r mulrA.
 rewrite (expr2 l%:num) ler_add2l; apply: ler_paddl.
@@ -270,13 +279,6 @@ Proof. exact: bounded_closed_compact K_bounded K_closed. Qed.
 
 Lemma Mp_ms_gt0 (p : U) : 0 < M%:num + m%:num * (p..[3] ^+ 2).
 Proof. by rewrite ltr_spaddl // pmulr_rge0 // sqr_ge0. Qed.
-
-Lemma ge0_expr_ndecr (R : realDomainType) n (x y : R) :
-  0 <= x <= y -> x ^+ n <= y ^+ n.
-Proof.
-move=> /andP [xge0 yge0]; elim: n => [|n ihn]; first by rewrite !expr0.
-by rewrite !exprS ler_pmul // exprn_ge0.
-Qed.
 
 Lemma E_small p : V p < B -> `|E p| < kv%:num / (ke%:num * (M%:num + m%:num)).
 Proof.
@@ -340,11 +342,11 @@ apply (@eq0_derive1_cst (f : R^o -> R^o) 0 t); last first.
 move=> s s0t; have sge0 : s >= 0 by rewrite (itvP s0t).
 have [_ /(_ _ sge0) dsol] := sol_is_sol sol0 solP Kp.
 apply: is_derive_eq.
-by rewrite !mxE /= [_ *: (_ * _)]mulrCA -!mulrDr addrC mulNr subrr.
+rewrite 2!mxE/=.
+rewrite /GRing.scale/=.
+rewrite mulrCA.
+by rewrite -!mulrDr addrC mulNr subrr.
 Qed.
-
-Lemma mul2r (R : ringType) (x : R) : 2 * x = x + x.
-Proof. by rewrite -mulr2n mulr_natl. Qed.
 
 Lemma is_derive_Esol p t :
   K p -> 0 <= t -> is_derive (t : R^o) 1 (E \o (sol p) : _ -> R^o)
@@ -506,7 +508,7 @@ Qed.
 Lemma limSKinvar : is_invariant sol (limS sol K).
 Proof.
 move=> p limSKp t tge0.
-exact: (@invariant_limS _ _ _ K_compact _ sol0 solP sol_cont Kinvar).
+exact: (@invariant_limS _ _ _ _ K_compact _ sol0 solP sol_cont Kinvar).
 Qed.
 
 Lemma subset_limSK_K : limS sol K `<=` K.
@@ -531,7 +533,6 @@ have -> : derive1 (V \o sol p : _ -> R^o) t =
   have Ksolpt : K (sol p t) by apply: subset_limSK_K.
   have dVsolt' := is_derive_Vsol Ksolpt (lexx _); rewrite derive1E derive_val.
   rewrite -(solD sol0 solP Kinvar) //.
-  rewrite RplusE.
   by rewrite add0r.
 apply: (stable_limS K_compact sol0 solP sol_cont Kinvar (V:=V)) limSKsolp.
 - move=> q Kq; have /(_ q) := V_continuous; apply: cvg_trans.

--- a/pendulum.v
+++ b/pendulum.v
@@ -1,10 +1,10 @@
 From HB Require Import structures.
 From mathcomp Require Import ssreflect ssrfun ssrbool ssrnat eqtype choice seq.
-From mathcomp Require Import order.
+From mathcomp Require Import order interval_inference.
 From mathcomp Require Import fintype bigop ssralg ssrnum finmap interval ssrint.
 From mathcomp Require Import matrix zmodp ring.
 From mathcomp Require Import mathcomp_extra.
-From mathcomp Require Import boolp reals Rstruct classical_sets signed functions.
+From mathcomp Require Import boolp reals classical_sets functions.
 From mathcomp Require Import topology normedtype prodnormedzmodule landau derive.
 Require Import lasalle.
 
@@ -324,14 +324,14 @@ Lemma eq0_derive1_cst (f : R^o -> R^o) (a b : R) :
   forall t, t \in `[a, b] -> f t = f a.
 Proof.
 move=> f'eq0 t tab; apply/eqP; rewrite eq_le; apply/andP; split.
-  apply: (@ler0_derive1_nincr _ _ a b) => //; rewrite ?(itvP tab) //;[
+  apply: (@ler0_derive1_le_cc _ _ a b) => //; rewrite ?(itvP tab) //;[
     by move=> x /subset_itv_oo_cc /f'eq0 // df; rewrite derive1E derive_val..|].
   apply: continuous_in_subspaceT => x.
   rewrite inE/= => /f'eq0.
   move=> /(@ex_derive _ [the normedModType R of R^o]).
   move=> /derivable1_diffP /differentiable_continuous.
   exact.
-apply: (@le0r_derive1_ndecr _ _ a b) => //; rewrite ?(itvP tab) //;[
+apply: (@ger0_derive1_ndecr _ _ a b) => //; rewrite ?(itvP tab) //;[
   by move=> x /subset_itv_oo_cc /f'eq0 // df; rewrite derive1E derive_val..|].
 apply: continuous_in_subspaceT => x.
 rewrite inE/= => /f'eq0.
@@ -392,6 +392,7 @@ rewrite [_ * (_ - _ * y)]mulrDr addrA -[- (_ * y)]mulNr [_ * (_ * y)]mulrA.
 rewrite [_ + _ * y + _]addrAC; apply: (canLR (subrK _)); rewrite -mulrBl.
 rewrite [in RHS]mulrN opprK mulrACA [_ ^+2 / _]mulrAC mulfVK //.
 rewrite [_ / _]mulrC ![_^-1 * _]mulrA [_^-1 * _ * _]mulrC mulVKf //.
+rewrite /=.
 ring.
 Qed.
 
@@ -416,7 +417,7 @@ apply: (canLR (mulfK _)) => //; rewrite [kv%:num * _]mulrDr addrA addrAC.
 apply: (canLR (subrK _)); rewrite mulrAC -mulrDl /fctrl [LHS]mulrA.
 have circp : (sol p t)..[2] ^+ 2 + (sol p t)..[3] ^+ 2 = 1 by apply: circ_invar.
 have fctrl_def := fctrl_wdef circp Vsolpt_s; apply: (canLR (mulfK _)) => //.
-ring.
+rewrite /=; ring.
 Qed.
 
 Lemma defset_invar p : K p -> forall t, 0 <= t ->
@@ -501,18 +502,20 @@ apply: le_trans Vp_s; rewrite -{2}[p]sol0.
 have Vsol_deriv : forall s, s \in `[0, t] ->
   is_derive (s : R^o) 1 (V \o sol p : _ -> R^o)
   (- kd%:num * (sol p s)..[1] ^+ 2) by move=> s /andP [/(is_derive_Vsol Kp)].
-apply: (@ler0_derive1_nincr _ (V \o sol p) 0 t);[| | |by [] |by [] |by []].
-  move=> x /subset_itv_oo_cc /Vsol_deriv.
+apply: (@ler0_derive1_le_cc _ (V \o sol p) 0 t);[| | | | |by []].
+- move=> x /subset_itv_oo_cc /Vsol_deriv.
   by apply: (@ex_derive _ [the normedModType R of R^o]).
-  move=> x /subset_itv_oo_cc /Vsol_deriv.
+- move=> x /subset_itv_oo_cc /Vsol_deriv.
   rewrite derive1E.
   case => _ ->.
   by rewrite mulr_le0_ge0// sqr_ge0.
-apply: continuous_in_subspaceT => x.
-rewrite inE/= => /Vsol_deriv.
-move=> /(@ex_derive _ [the normedModType R of R^o]).
-move=> /derivable1_diffP /differentiable_continuous.
-exact.
+- apply: continuous_in_subspaceT => x.
+  rewrite inE/= => /Vsol_deriv.
+  move=> /(@ex_derive _ [the normedModType R of R^o]).
+  move=> /derivable1_diffP /differentiable_continuous.
+  exact.
+- by rewrite in_itv/= lexx tge0.
+- by rewrite in_itv/= lexx tge0.
 Qed.
 
 Definition homoclinic_orbit : set U := [set p : U | p..[0] = 0 /\ p..[1] = 0 /\
@@ -642,7 +645,7 @@ rewrite opprD [RHS]mulrDl [RHS]addrC; apply/(canRL (subrK _))/Logic.eq_sym.
 rewrite mulrC -mulNr mulrA mulrA; apply: (canLR (mulfK _)) => //.
 rewrite [RHS]mulrDr [LHS]mulrDr addrC; apply: (canLR (subrK _)).
 rewrite mulrA -[in X in X / _]mulrA; apply: (canLR (mulfK _)) => //.
-ring.
+rewrite /=; ring.
 Qed.
 
 Lemma div_fctrl_mP p t : limS sol K p -> 0 <= t ->
@@ -666,7 +669,7 @@ apply: (canLR (mulfK _)); last apply/Logic.eq_sym.
 rewrite mulrCA mulrA mulrA [l%:num * _ in LHS]mulrC mulrVK ?unitfE //.
 have [] : K (sol p t) by apply/subset_limSK_K/limSKinvar.
 rewrite addrC => /(canRL (addrK _)) -> _.
-ring.
+rewrite /=; ring.
 Qed.
 
 Lemma En0_fctrlsol_const p t :


### PR DESCRIPTION
This PR updates `lasalle.v` and `pendulum.v` to compile with MathComp-Analysis 1.12.0 and algebra-tactics.

FYI: @yosakaon @CohenCyril 